### PR TITLE
Import

### DIFF
--- a/pooltool/__init__.py
+++ b/pooltool/__init__.py
@@ -5,46 +5,12 @@ All units are SI unless otherwise stated.
 
 __version__ = '0.1'
 
-from pooltool.error import ConfigError
+from .constants import *
 
 import numpy as np
-import importlib.util
-
-from pathlib import Path
-
 np.set_printoptions(precision=10, suppress=True)
-
-# Taken from https://billiards.colostate.edu/faq/physics/physical-properties/
-g = 9.8 # gravitational constant
-M = 0.567 # cue mass
-cue_length = 1.4732 # 58 inches
-cue_tip_radius = 0.007 # 14mm tip
-cue_butt_radius = 0.02
-m = 0.170097 # ball mass
-R = 0.028575 # ball radius
-u_s = 0.2 # sliding friction
-u_r = 0.01 # rolling friction
-u_sp = 10 * 2/5*R/9 # spinning friction
-
-english_fraction = 0.5
-
-table_length = 1.9812 # 7-foot table (78x39 in^2 playing surface)
-table_width = 1.9812/2 # 7-foot table (78x39 in^2 playing surface)
-table_height = 0.708
-lights_height = 1.99 # relative to playing surface
-cushion_width = 2*2.54/100 # 2 inches x 2.54 cm/inch x 1/100 m/cm
-cushion_height_fraction = 0.64
-cushion_height = cushion_height_fraction*2*R
-corner_pocket_width = 0.118
-corner_pocket_angle = 5.3 # degrees
-corner_pocket_depth = 0.0398
-corner_pocket_radius = 0.124/2
-corner_jaw_radius = 0.0419/2
-side_pocket_width = 0.137
-side_pocket_angle = 7.14 # degrees
-side_pocket_depth = 0.00437
-side_pocket_radius = 0.129/2
-side_jaw_radius = 0.0159/2
+#tol = np.finfo(np.float).eps * 100
+tol = 1e-12
 
 # Ball states
 stationary=0
@@ -63,5 +29,3 @@ state_dict = {
 
 nontranslating = [stationary, spinning, pocketed]
 
-#tol = np.finfo(np.float).eps * 100
-tol = 1e-12

--- a/pooltool/__init__.py
+++ b/pooltool/__init__.py
@@ -5,6 +5,9 @@ All units are SI unless otherwise stated.
 
 __version__ = '0.1'
 
+import pooltool.utils as utils
+import pooltool.ani.utils as autils
+
 from .constants import *
 
 import numpy as np

--- a/pooltool/__init__.py
+++ b/pooltool/__init__.py
@@ -8,27 +8,8 @@ __version__ = '0.1'
 import pooltool.utils as utils
 import pooltool.ani.utils as autils
 
+from .objects.ball import *
+from .objects.cue import *
+from .objects.table import *
 from .constants import *
-
-import numpy as np
-np.set_printoptions(precision=10, suppress=True)
-#tol = np.finfo(np.float).eps * 100
-tol = 1e-12
-
-# Ball states
-stationary=0
-spinning=1
-sliding=2
-rolling=3
-pocketed=4
-
-state_dict = {
-    0: 'stationary',
-    1: 'spinning',
-    2: 'sliding',
-    3: 'rolling',
-    4: 'pocketed',
-}
-
-nontranslating = [stationary, spinning, pocketed]
 

--- a/pooltool/__init__.py
+++ b/pooltool/__init__.py
@@ -11,5 +11,10 @@ import pooltool.ani.utils as autils
 from .objects.ball import *
 from .objects.cue import *
 from .objects.table import *
+
+from .ani.animate import *
+
 from .constants import *
+from .layouts import *
+from .evolution import *
 

--- a/pooltool/ani/__init__.py
+++ b/pooltool/ani/__init__.py
@@ -1,16 +1,16 @@
 #! /usr/bin/env python
 
 import ast
-import pooltool
+import pooltool as pt
 import configparser
-import pooltool.utils as utils
 
+from pooltool.utils import panda_path
 from pooltool.error import ConfigError, TableConfigError
 
 from pathlib import Path
 from panda3d.core import *
 
-loadPrcFile(utils.panda_path(Path(pooltool.__file__).parent / 'config' / 'config_panda3d.prc'))
+loadPrcFile(panda_path(Path(pt.__file__).parent / 'config' / 'config_panda3d.prc'))
 
 menu_text_scale = 0.07
 menu_text_scale_small = 0.04
@@ -71,15 +71,15 @@ ball_highlight = {
     'shadow_scale_amplitude': 0.4,
 }
 
-model_dir = Path(pooltool.__file__).parent / 'models'
+model_dir = Path(pt.__file__).parent / 'models'
 
-logo_dir = Path(pooltool.__file__).parent / 'logo'
+logo_dir = Path(pt.__file__).parent / 'logo'
 logo_paths = {
-    'default': utils.panda_path(logo_dir / 'logo.png'),
-    'small': utils.panda_path(logo_dir / 'logo_small.png'),
-    'smaller': utils.panda_path(logo_dir / 'logo_smaller.png'),
-    'pt': utils.panda_path(logo_dir / 'logo_pt.png'),
-    'pt_smaller': utils.panda_path(logo_dir / 'logo_pt_smaller.png'),
+    'default': panda_path(logo_dir / 'logo.png'),
+    'small': panda_path(logo_dir / 'logo_small.png'),
+    'smaller': panda_path(logo_dir / 'logo_smaller.png'),
+    'pt': panda_path(logo_dir / 'logo_pt.png'),
+    'pt_smaller': panda_path(logo_dir / 'logo_pt_smaller.png'),
 }
 
 

--- a/pooltool/ani/animate.py
+++ b/pooltool/ani/animate.py
@@ -92,13 +92,14 @@ class ModeManager(MenuMode, AimMode, StrokeMode, ViewMode, ShotMode, CamLoadMode
             self.keymap[key] = self.action_state_defaults[self.mode][key]
 
 
-class Interface(ShowBase, ModeManager):
+class Interface(ShowBase, ModeManager, HUD):
     is_game = None
     def __init__(self, shot=None):
         if self.is_game is None:
             raise Exception(f"'{self.__class__.__name__}' must set 'is_game' attribute")
 
         super().__init__(self)
+        HUD.__init__(self)
         base.setBackgroundColor(0.04, 0.04, 0.04)
         simplepbr.init(enable_shadows=ani.settings['graphics']['shadows'], max_lights=13)
 
@@ -156,6 +157,7 @@ class Interface(ShowBase, ModeManager):
         self.environment.unload_room()
         self.environment.unload_lights()
         gc.collect()
+        self.destroy_hud()
 
 
     def init_system_nodes(self):
@@ -317,6 +319,7 @@ class ShotViewer(Interface):
         self.help_hint.hide()
         self.mouse = Mouse()
         self.init_system_nodes()
+        self.init_hud()
         params = dict(
             init_animations = True,
             single_instance = True,
@@ -344,13 +347,12 @@ class ShotViewer(Interface):
         self.stop()
 
 
-class Play(Interface, Menus, HUD):
+class Play(Interface, Menus):
     is_game = True
 
     def __init__(self, *args, **kwargs):
         Interface.__init__(self, shot=None)
         Menus.__init__(self)
-        HUD.__init__(self)
 
         self.change_mode('menu')
 
@@ -376,7 +378,6 @@ class Play(Interface, Menus, HUD):
 
     def close_scene(self):
         Interface.close_scene(self)
-        self.destroy_hud()
 
 
     def setup(self):

--- a/pooltool/ani/animate.py
+++ b/pooltool/ani/animate.py
@@ -437,7 +437,7 @@ class Play(Interface, Menus, HUD):
 
 
     def setup_balls(self):
-        self.balls = self.game.layout.get_balls_dict()
+        self.balls = self.game.balls
         self.cueing_ball = self.game.set_initial_cueing_ball(self.balls)
 
 

--- a/pooltool/ani/animate.py
+++ b/pooltool/ani/animate.py
@@ -281,7 +281,7 @@ class ShotViewer(Interface):
 
     def create_instructions(self):
         self.instructions = OnscreenText(
-            text = "<escape> to exit",
+            text = "Press <escape> to exit",
             pos = (-1.55, 0.93),
             scale = ani.menu_text_scale*0.7,
             fg = (1,1,1,1),

--- a/pooltool/ani/animate.py
+++ b/pooltool/ani/animate.py
@@ -1,8 +1,7 @@
 #! /usr/bin/env python
 
-import pooltool
+import pooltool as pt
 import pooltool.ani as ani
-import pooltool.utils as utils
 import pooltool.games as games
 import pooltool.ani.environment as environment
 
@@ -176,11 +175,11 @@ class Interface(ShowBase, ModeManager):
 
     def init_environment(self):
         if ani.settings['graphics']['physical_based_rendering']:
-            room_path = utils.panda_path(ani.model_dir / 'room/room_pbr.glb')
-            floor_path = utils.panda_path(ani.model_dir / 'room/floor_pbr.glb')
+            room_path = pt.utils.panda_path(ani.model_dir / 'room/room_pbr.glb')
+            floor_path = pt.utils.panda_path(ani.model_dir / 'room/floor_pbr.glb')
         else:
-            room_path = utils.panda_path(ani.model_dir / 'room/room.glb')
-            floor_path = utils.panda_path(ani.model_dir / 'room/floor.glb')
+            room_path = pt.utils.panda_path(ani.model_dir / 'room/room.glb')
+            floor_path = pt.utils.panda_path(ani.model_dir / 'room/floor.glb')
 
         self.environment = environment.Environment(self.table)
         if ani.settings['graphics']['room']:
@@ -194,7 +193,7 @@ class Interface(ShowBase, ModeManager):
     def monitor(self, task):
         #print(f"Mode: {self.mode}")
         #print(f"Tasks: {list(self.tasks.keys())}")
-        #print(f"Memory: {utils.get_total_memory_usage()}")
+        #print(f"Memory: {pt.utils.get_total_memory_usage()}")
         #print(f"Actions: {[k for k in self.keymap if self.keymap[k]]}")
         #print(f"Keymap: {self.keymap}")
         #print(f"Frame: {self.frame}")

--- a/pooltool/ani/animate.py
+++ b/pooltool/ani/animate.py
@@ -26,6 +26,12 @@ import simplepbr
 from panda3d.core import *
 from direct.showbase.ShowBase import ShowBase
 
+__all__ = [
+    'Interface',
+    'ShotViewer',
+    'Play',
+]
+
 
 class ModeManager(MenuMode, AimMode, StrokeMode, ViewMode, ShotMode, CamLoadMode, CamSaveMode,
                   CalculateMode, PickBallMode, GameOverMode, CallShotMode, BallInHandMode):

--- a/pooltool/ani/animate.py
+++ b/pooltool/ani/animate.py
@@ -209,6 +209,62 @@ class Interface(ShowBase, ModeManager):
         return task.cont
 
 
+    def init_help_page(self):
+        self.help_hint = OnscreenText(
+            text = "Press 'h' to toggle help",
+            pos = (-1.55, 0.93),
+            scale = ani.menu_text_scale*0.9,
+            fg = (1,1,1,1),
+            align = TextNode.ALeft,
+            parent = aspect2d,
+        )
+        self.help_hint.show()
+
+        self.help_node = aspect2d.attachNewNode('help')
+
+        def add_instruction(pos, msg, title=False):
+            text = OnscreenText(
+                text = msg,
+                style = 1,
+                fg = (1, 1, 1, 1),
+                parent = base.a2dTopLeft,
+                align = TextNode.ALeft,
+                pos = (-1.45 if not title else -1.55, 0.85-pos),
+                scale = ani.menu_text_scale if title else 0.7*ani.menu_text_scale,
+            )
+            text.reparentTo(self.help_node)
+
+        h = lambda x: 0.06*x
+        add_instruction(h(1), "Camera controls", True)
+        add_instruction(h(2), "Rotate - [mouse]")
+        add_instruction(h(3), "Pan - [hold v]")
+        add_instruction(h(4), "Zoom - [hold left-click]")
+
+        add_instruction(h(6), "Aim controls", True)
+        add_instruction(h(7), "Enter aim mode - [a]")
+        add_instruction(h(8), "Apply english - [hold e]")
+        add_instruction(h(9), "Elevate cue - [hold b]")
+        add_instruction(h(10), "Precise aiming - [hold f]")
+        add_instruction(h(11), "Raise head - [hold t]")
+
+        add_instruction(h(13), "Shot controls", True)
+        add_instruction(h(14), "Stroke - [hold s] (move mouse down then up)")
+        add_instruction(h(15), "Take next shot - [a]")
+        add_instruction(h(16), "Undo shot - [z]")
+        add_instruction(h(17), "Replay shot - [r]")
+        add_instruction(h(18), "Pause shot - [space]")
+        add_instruction(h(19), "Rewind - [hold left-arrow]")
+        add_instruction(h(20), "Fast forward - [hold right-arrow]")
+        add_instruction(h(21), "Slow down - [down-arrow]")
+        add_instruction(h(22), "Speed up - [up-arrow]")
+
+        add_instruction(h(24), "Other controls", True)
+        add_instruction(h(25), "Cue different ball - [hold q]\n    (select with mouse, click to confirm)")
+        add_instruction(h(27), "Move ball - [hold g]\n    (click once to select ball, move with mouse, then click to confirm move")
+
+        self.help_node.hide()
+
+
 class ShotViewer(Interface):
     is_game = False
 
@@ -238,7 +294,7 @@ class ShotViewer(Interface):
         self.standby_screen.add_image(ani.logo_paths['default'], pos=(0,0,0), scale=(0.5, 1, 0.44))
 
         text = OnscreenText(
-            text = 'Standing by...',
+            text = 'GUI standing by...',
             style = 1,
             fg = (1, 1, 1, 1),
             parent = self.standby_screen.titleMenu,
@@ -257,6 +313,8 @@ class ShotViewer(Interface):
 
         self.standby_screen.hide()
         self.instructions.show()
+        self.init_help_page()
+        self.help_hint.hide()
         self.mouse = Mouse()
         self.init_system_nodes()
         params = dict(
@@ -306,62 +364,6 @@ class Play(Interface, Menus, HUD):
             frameSync = None,
             timeslicePriority = None
         )
-
-
-    def init_help_page(self):
-        text = OnscreenText(
-            text = "Press 'h' to toggle help",
-            pos = (-1.55, 0.93),
-            scale = ani.menu_text_scale*0.9,
-            fg = (1,1,1,1),
-            align = TextNode.ALeft,
-            parent = aspect2d,
-        )
-        text.show()
-
-        self.help_node = aspect2d.attachNewNode('help')
-
-        def add_instruction(pos, msg, title=False):
-            text = OnscreenText(
-                text = msg,
-                style = 1,
-                fg = (1, 1, 1, 1),
-                parent = base.a2dTopLeft,
-                align = TextNode.ALeft,
-                pos = (-1.45 if not title else -1.55, 0.85-pos),
-                scale = ani.menu_text_scale if title else 0.7*ani.menu_text_scale,
-            )
-            text.reparentTo(self.help_node)
-
-        h = lambda x: 0.06*x
-        add_instruction(h(1), "Camera controls", True)
-        add_instruction(h(2), "Rotate - [mouse]")
-        add_instruction(h(3), "Pan - [hold v]")
-        add_instruction(h(4), "Zoom - [hold left-click]")
-
-        add_instruction(h(6), "Aim controls", True)
-        add_instruction(h(7), "Enter aim mode - [a]")
-        add_instruction(h(8), "Apply english - [hold e]")
-        add_instruction(h(9), "Elevate cue - [hold b]")
-        add_instruction(h(10), "Precise aiming - [hold f]")
-        add_instruction(h(11), "Raise head - [hold t]")
-
-        add_instruction(h(13), "Shoot controls", True)
-        add_instruction(h(14), "Stroke - [hold s] (move mouse down then up)")
-        add_instruction(h(15), "Take next shot - [a]")
-        add_instruction(h(16), "Undo shot - [z]")
-        add_instruction(h(17), "Replay shot - [r]")
-        add_instruction(h(18), "Pause shot - [space]")
-        add_instruction(h(19), "Rewind - [hold left-arrow]")
-        add_instruction(h(20), "Fast forward - [hold right-arrow]")
-        add_instruction(h(21), "Slow down - [down-arrow]")
-        add_instruction(h(22), "Speed up - [up-arrow]")
-
-        add_instruction(h(24), "Other controls", True)
-        add_instruction(h(25), "Cue different ball - [hold q]\n    (select with mouse, click to confirm)")
-        add_instruction(h(27), "Move ball - [hold g]\n    (click once to select ball, move with mouse, then click to confirm move")
-
-        self.help_node.hide()
 
 
     def go(self):

--- a/pooltool/ani/animate.py
+++ b/pooltool/ani/animate.py
@@ -248,7 +248,13 @@ class ShotViewer(Interface):
         )
 
 
-    def start(self):
+    def show(self, shot=None):
+        if shot:
+            self.set_shot(shot)
+
+        if self.shot is None:
+            raise ConfigError("ShotViewer.show :: No shot passed and no shot set.")
+
         self.standby_screen.hide()
         self.instructions.show()
         self.mouse = Mouse()
@@ -267,6 +273,11 @@ class ShotViewer(Interface):
         self.instructions.hide()
         base.graphicsEngine.renderFrame()
         base.graphicsEngine.renderFrame()
+
+        self.shot = None
+        self.balls = None
+        self.table = None
+        self.cue = None
 
         self.taskMgr.stop()
 

--- a/pooltool/ani/environment.py
+++ b/pooltool/ani/environment.py
@@ -1,8 +1,5 @@
 #! /usr/bin/env python
 
-import pooltool
-
-from pooltool.ani import settings
 from pooltool.utils import panda_path
 
 from pathlib import Path

--- a/pooltool/ani/hud.py
+++ b/pooltool/ani/hud.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 
-import pooltool
 import pooltool.ani as ani
 import pooltool.ani.utils as autils
 

--- a/pooltool/ani/hud.py
+++ b/pooltool/ani/hud.py
@@ -55,8 +55,9 @@ class HUD(object):
 
 
     def update_hud(self, task):
-        self.update_log_window()
-        self.update_player_stats()
+        if self.is_game:
+            self.update_log_window()
+            self.update_player_stats()
 
         return task.cont
 

--- a/pooltool/ani/menu.py
+++ b/pooltool/ani/menu.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-import pooltool
+import pooltool as pt
 import pooltool.ani as ani
 import pooltool.games as games
 
@@ -51,23 +51,23 @@ class Menus(object):
 
         m.add_dropdown(ani.options_table, options=list(ani.table_config.keys()) + ['custom'], command=self.show_custom_table_options)
 
-        m.add_dropdown(ani.options_table_type, options=list(pooltool.objects.table.table_types.keys()), scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_table_length, initial=f"{pooltool.table_length:.5f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_table_width, initial=f"{pooltool.table_width:.5f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_table_height, initial=f"{pooltool.table_height:.5f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_lights_height, initial=f"{pooltool.lights_height:.5f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_cushion_width, initial=f"{pooltool.cushion_width:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_cushion_height, initial=f"{pooltool.cushion_height:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_corner_pocket_width, initial=f"{pooltool.corner_pocket_width:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_corner_pocket_angle, initial=f"{pooltool.corner_pocket_angle:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_corner_pocket_depth, initial=f"{pooltool.corner_pocket_depth:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_corner_pocket_radius, initial=f"{pooltool.corner_pocket_radius:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_corner_jaw_radius, initial=f"{pooltool.corner_jaw_radius:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_side_pocket_width, initial=f"{pooltool.side_pocket_width:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_side_pocket_angle, initial=f"{pooltool.side_pocket_angle:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_side_pocket_depth, initial=f"{pooltool.side_pocket_depth:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_side_pocket_radius, initial=f"{pooltool.side_pocket_radius:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_side_jaw_radius, initial=f"{pooltool.side_jaw_radius:.3f}", scale=ani.menu_text_scale_small)
+        m.add_dropdown(ani.options_table_type, options=list(pt.objects.table.table_types.keys()), scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_table_length, initial=f"{pt.table_length:.5f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_table_width, initial=f"{pt.table_width:.5f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_table_height, initial=f"{pt.table_height:.5f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_lights_height, initial=f"{pt.lights_height:.5f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_cushion_width, initial=f"{pt.cushion_width:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_cushion_height, initial=f"{pt.cushion_height:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_corner_pocket_width, initial=f"{pt.corner_pocket_width:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_corner_pocket_angle, initial=f"{pt.corner_pocket_angle:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_corner_pocket_depth, initial=f"{pt.corner_pocket_depth:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_corner_pocket_radius, initial=f"{pt.corner_pocket_radius:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_corner_jaw_radius, initial=f"{pt.corner_jaw_radius:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_side_pocket_width, initial=f"{pt.side_pocket_width:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_side_pocket_angle, initial=f"{pt.side_pocket_angle:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_side_pocket_depth, initial=f"{pt.side_pocket_depth:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_side_pocket_radius, initial=f"{pt.side_pocket_radius:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_side_jaw_radius, initial=f"{pt.side_jaw_radius:.3f}", scale=ani.menu_text_scale_small)
 
         self.menus['table'] = m
 
@@ -91,10 +91,10 @@ class Menus(object):
         m = GenericMenu(title = 'Ball customization')
         m.add_button('Back', lambda: self.show_menu('options'), scale=ani.menu_text_scale)
 
-        m.add_direct_entry(ani.options_ball_diameter, initial=f"{pooltool.R*2:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_friction_roll, initial=f"{pooltool.u_r:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_friction_slide, initial=f"{pooltool.u_s:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_friction_spin, initial=f"{pooltool.u_sp:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_ball_diameter, initial=f"{pt.R*2:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_friction_roll, initial=f"{pt.u_r:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_friction_slide, initial=f"{pt.u_s:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_friction_spin, initial=f"{pt.u_sp:.3f}", scale=ani.menu_text_scale_small)
 
         self.menus['balls'] = m
 

--- a/pooltool/ani/menu.py
+++ b/pooltool/ani/menu.py
@@ -3,6 +3,7 @@
 import pooltool as pt
 import pooltool.ani as ani
 import pooltool.games as games
+import pooltool.constants as c
 
 from pooltool.utils import panda_path
 
@@ -52,22 +53,22 @@ class Menus(object):
         m.add_dropdown(ani.options_table, options=list(ani.table_config.keys()) + ['custom'], command=self.show_custom_table_options)
 
         m.add_dropdown(ani.options_table_type, options=list(pt.objects.table.table_types.keys()), scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_table_length, initial=f"{pt.table_length:.5f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_table_width, initial=f"{pt.table_width:.5f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_table_height, initial=f"{pt.table_height:.5f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_lights_height, initial=f"{pt.lights_height:.5f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_cushion_width, initial=f"{pt.cushion_width:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_cushion_height, initial=f"{pt.cushion_height:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_corner_pocket_width, initial=f"{pt.corner_pocket_width:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_corner_pocket_angle, initial=f"{pt.corner_pocket_angle:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_corner_pocket_depth, initial=f"{pt.corner_pocket_depth:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_corner_pocket_radius, initial=f"{pt.corner_pocket_radius:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_corner_jaw_radius, initial=f"{pt.corner_jaw_radius:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_side_pocket_width, initial=f"{pt.side_pocket_width:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_side_pocket_angle, initial=f"{pt.side_pocket_angle:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_side_pocket_depth, initial=f"{pt.side_pocket_depth:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_side_pocket_radius, initial=f"{pt.side_pocket_radius:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_side_jaw_radius, initial=f"{pt.side_jaw_radius:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_table_length, initial=f"{c.table_length:.5f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_table_width, initial=f"{c.table_width:.5f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_table_height, initial=f"{c.table_height:.5f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_lights_height, initial=f"{c.lights_height:.5f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_cushion_width, initial=f"{c.cushion_width:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_cushion_height, initial=f"{c.cushion_height:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_corner_pocket_width, initial=f"{c.corner_pocket_width:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_corner_pocket_angle, initial=f"{c.corner_pocket_angle:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_corner_pocket_depth, initial=f"{c.corner_pocket_depth:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_corner_pocket_radius, initial=f"{c.corner_pocket_radius:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_corner_jaw_radius, initial=f"{c.corner_jaw_radius:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_side_pocket_width, initial=f"{c.side_pocket_width:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_side_pocket_angle, initial=f"{c.side_pocket_angle:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_side_pocket_depth, initial=f"{c.side_pocket_depth:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_side_pocket_radius, initial=f"{c.side_pocket_radius:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_side_jaw_radius, initial=f"{c.side_jaw_radius:.3f}", scale=ani.menu_text_scale_small)
 
         self.menus['table'] = m
 
@@ -91,10 +92,10 @@ class Menus(object):
         m = GenericMenu(title = 'Ball customization')
         m.add_button('Back', lambda: self.show_menu('options'), scale=ani.menu_text_scale)
 
-        m.add_direct_entry(ani.options_ball_diameter, initial=f"{pt.R*2:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_friction_roll, initial=f"{pt.u_r:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_friction_slide, initial=f"{pt.u_s:.3f}", scale=ani.menu_text_scale_small)
-        m.add_direct_entry(ani.options_friction_spin, initial=f"{pt.u_sp:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_ball_diameter, initial=f"{c.R*2:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_friction_roll, initial=f"{c.u_r:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_friction_slide, initial=f"{c.u_s:.3f}", scale=ani.menu_text_scale_small)
+        m.add_direct_entry(ani.options_friction_spin, initial=f"{c.u_sp:.3f}", scale=ani.menu_text_scale_small)
 
         self.menus['balls'] = m
 

--- a/pooltool/ani/modes/__init__.py
+++ b/pooltool/ani/modes/__init__.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 
-import pooltool.ani.utils as autils
 import pooltool.ani.action as action
 
 import re

--- a/pooltool/ani/modes/aim.py
+++ b/pooltool/ani/modes/aim.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 
 import pooltool.ani as ani
-import pooltool.utils as utils
 import pooltool.ani.utils as autils
 
 from pooltool.ani.modes import Mode, action

--- a/pooltool/ani/modes/ball_in_hand.py
+++ b/pooltool/ani/modes/ball_in_hand.py
@@ -1,8 +1,7 @@
 #! /usr/bin/env python
 
-import pooltool
+import pooltool as pt
 import pooltool.ani as ani
-import pooltool.ani.utils as autils
 
 from pooltool.utils import panda_path
 from pooltool.ani.modes import Mode, action
@@ -188,7 +187,7 @@ class BallInHandMode(Mode):
         for ball in self.balls.values():
             if ball.id not in self.game.active_player.ball_in_hand:
                 continue
-            if ball.s == pooltool.pocketed:
+            if ball.s == pt.pocketed:
                 continue
             d = np.linalg.norm(ball.rvw[0] - cam_pos)
             if d < d_min:

--- a/pooltool/ani/modes/ball_in_hand.py
+++ b/pooltool/ani/modes/ball_in_hand.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
-import pooltool as pt
 import pooltool.ani as ani
+import pooltool.constants as c
 
 from pooltool.utils import panda_path
 from pooltool.ani.modes import Mode, action
@@ -187,7 +187,7 @@ class BallInHandMode(Mode):
         for ball in self.balls.values():
             if ball.id not in self.game.active_player.ball_in_hand:
                 continue
-            if ball.s == pt.pocketed:
+            if ball.s == c.pocketed:
                 continue
             d = np.linalg.norm(ball.rvw[0] - cam_pos)
             if d < d_min:

--- a/pooltool/ani/modes/calculate.py
+++ b/pooltool/ani/modes/calculate.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
+import pooltool as pt
 import pooltool.ani as ani
-import pooltool.ani.utils as autils
 import pooltool.evolution as evolution
 
 from pooltool.ani.menu import GenericMenu
@@ -84,7 +84,7 @@ class CalculateMode(Mode):
         with self.mouse:
             s = -self.mouse.get_dy()*ani.zoom_sensitivity
 
-        self.player_cam.node.setPos(autils.multiply_cw(self.player_cam.node.getPos(), 1-s))
+        self.player_cam.node.setPos(pt.autils.multiply_cw(self.player_cam.node.getPos(), 1-s))
 
 
     def move_camera_calculate(self):

--- a/pooltool/ani/modes/call_shot.py
+++ b/pooltool/ani/modes/call_shot.py
@@ -1,8 +1,7 @@
 #! /usr/bin/env python
 
-import pooltool
+import pooltool as pt
 import pooltool.ani as ani
-import pooltool.ani.utils as autils
 
 from pooltool.utils import panda_path
 from pooltool.ani.modes import Mode, action
@@ -202,7 +201,7 @@ class CallShotMode(Mode):
         for ball in self.balls.values():
             if ball.id not in self.game.active_player.target_balls:
                 continue
-            if ball.s == pooltool.pocketed:
+            if ball.s == pt.pocketed:
                 continue
             d = np.linalg.norm(ball.rvw[0] - cam_pos)
             if d < d_min:

--- a/pooltool/ani/modes/call_shot.py
+++ b/pooltool/ani/modes/call_shot.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-import pooltool as pt
+import pooltool.constants as c
 import pooltool.ani as ani
 
 from pooltool.utils import panda_path
@@ -201,7 +201,7 @@ class CallShotMode(Mode):
         for ball in self.balls.values():
             if ball.id not in self.game.active_player.target_balls:
                 continue
-            if ball.s == pt.pocketed:
+            if ball.s == c.pocketed:
                 continue
             d = np.linalg.norm(ball.rvw[0] - cam_pos)
             if d < d_min:

--- a/pooltool/ani/modes/pick_ball.py
+++ b/pooltool/ani/modes/pick_ball.py
@@ -1,8 +1,8 @@
 #! /usr/bin/env python
 """A mode to for picking which ball to cue"""
 
-import pooltool as pt
 import pooltool.ani as ani
+import pooltool.constants as c
 
 from pooltool.ani.modes import Mode, action
 
@@ -104,7 +104,7 @@ class PickBallMode(Mode):
         for ball in self.balls.values():
             if ball.id not in self.game.active_player.can_cue:
                 continue
-            if ball.s == pt.pocketed:
+            if ball.s == c.pocketed:
                 continue
             d = np.linalg.norm(ball.rvw[0] - cam_pos)
             if d < d_min:

--- a/pooltool/ani/modes/pick_ball.py
+++ b/pooltool/ani/modes/pick_ball.py
@@ -1,9 +1,8 @@
 #! /usr/bin/env python
 """A mode to for picking which ball to cue"""
 
-import pooltool
+import pooltool as pt
 import pooltool.ani as ani
-import pooltool.ani.utils as autils
 
 from pooltool.ani.modes import Mode, action
 
@@ -105,7 +104,7 @@ class PickBallMode(Mode):
         for ball in self.balls.values():
             if ball.id not in self.game.active_player.can_cue:
                 continue
-            if ball.s == pooltool.pocketed:
+            if ball.s == pt.pocketed:
                 continue
             d = np.linalg.norm(ball.rvw[0] - cam_pos)
             if d < d_min:

--- a/pooltool/ani/modes/shot.py
+++ b/pooltool/ani/modes/shot.py
@@ -45,6 +45,9 @@ class ShotMode(Mode):
             self.shot.init_shot_animation()
             self.shot.loop_animation()
 
+        self.hud_elements.get('english').set(self.shot.cue.a, self.shot.cue.b)
+        self.hud_elements.get('jack').set(self.shot.cue.theta)
+
         self.accept('space', self.shot.toggle_pause)
         self.accept('arrow_up', self.shot.speed_up)
         self.accept('arrow_down', self.shot.slow_down)
@@ -94,10 +97,9 @@ class ShotMode(Mode):
             self.shot.cue.reset_state()
             self.shot.cue.set_render_state_as_object_state()
 
-            if self.is_game:
-                _, _, theta, a, b, _ = self.shot.cue.get_render_state()
-                english = self.hud_elements.get('english').set(a, b)
-                jack = self.hud_elements.get('jack').set(theta)
+            _, _, theta, a, b, _ = self.shot.cue.get_render_state()
+            self.hud_elements.get('english').set(a, b)
+            self.hud_elements.get('jack').set(theta)
 
             for ball in self.shot.balls.values():
                 ball.reset_angular_integration()

--- a/pooltool/constants.py
+++ b/pooltool/constants.py
@@ -4,6 +4,28 @@
 All units are SI unless otherwise stated.
 """
 
+import numpy as np
+np.set_printoptions(precision=10, suppress=True)
+#tol = np.finfo(np.float).eps * 100
+tol = 1e-12
+
+# Ball states
+stationary=0
+spinning=1
+sliding=2
+rolling=3
+pocketed=4
+
+state_dict = {
+    0: 'stationary',
+    1: 'spinning',
+    2: 'sliding',
+    3: 'rolling',
+    4: 'pocketed',
+}
+
+nontranslating = [stationary, spinning, pocketed]
+
 # Taken from https://billiards.colostate.edu/faq/physics/physical-properties/
 g = 9.8 # gravitational constant
 M = 0.567 # cue mass

--- a/pooltool/constants.py
+++ b/pooltool/constants.py
@@ -1,0 +1,38 @@
+#! /usr/bin/env python
+"""Constants and other
+
+All units are SI unless otherwise stated.
+"""
+
+# Taken from https://billiards.colostate.edu/faq/physics/physical-properties/
+g = 9.8 # gravitational constant
+M = 0.567 # cue mass
+cue_length = 1.4732 # 58 inches
+cue_tip_radius = 0.007 # 14mm tip
+cue_butt_radius = 0.02
+m = 0.170097 # ball mass
+R = 0.028575 # ball radius
+u_s = 0.2 # sliding friction
+u_r = 0.01 # rolling friction
+u_sp = 10 * 2/5*R/9 # spinning friction
+
+english_fraction = 0.5
+
+table_length = 1.9812 # 7-foot table (78x39 in^2 playing surface)
+table_width = 1.9812/2 # 7-foot table (78x39 in^2 playing surface)
+table_height = 0.708
+lights_height = 1.99 # relative to playing surface
+cushion_width = 2*2.54/100 # 2 inches x 2.54 cm/inch x 1/100 m/cm
+cushion_height_fraction = 0.64
+cushion_height = cushion_height_fraction*2*R
+corner_pocket_width = 0.118
+corner_pocket_angle = 5.3 # degrees
+corner_pocket_depth = 0.0398
+corner_pocket_radius = 0.124/2
+corner_jaw_radius = 0.0419/2
+side_pocket_width = 0.137
+side_pocket_angle = 7.14 # degrees
+side_pocket_depth = 0.00437
+side_pocket_radius = 0.129/2
+side_jaw_radius = 0.0159/2
+

--- a/pooltool/events.py
+++ b/pooltool/events.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-import pooltool
+import pooltool as pt
 import pooltool.utils as utils
 import pooltool.physics as physics
 
@@ -64,10 +64,10 @@ class BallBallCollision(Collision):
 
     def __init__(self, ball1, ball2, t=None):
         self.ball1_state_start = ball1.s
-        self.ball1_state_end = pooltool.sliding
+        self.ball1_state_end = pt.sliding
 
         self.ball2_state_start = ball2.s
-        self.ball2_state_end = pooltool.sliding
+        self.ball2_state_end = pt.sliding
 
         Collision.__init__(self, body1=ball1, body2=ball2, t=t)
 
@@ -76,7 +76,7 @@ class BallBallCollision(Collision):
         ball1, ball2 = self.agents
 
         rvw1, rvw2 = physics.resolve_ball_ball_collision(ball1.rvw, ball2.rvw)
-        s1, s2 = pooltool.sliding, pooltool.sliding
+        s1, s2 = pt.sliding, pt.sliding
 
         ball1.set(rvw1, s1, t=self.time)
         ball1.update_next_transition_event()
@@ -90,7 +90,7 @@ class BallCushionCollision(Collision):
 
     def __init__(self, ball, cushion, t=None):
         self.state_start = ball.s
-        self.state_end = pooltool.sliding
+        self.state_end = pt.sliding
 
         Collision.__init__(self, body1=ball, body2=cushion, t=t)
 
@@ -106,7 +106,7 @@ class BallCushionCollision(Collision):
             m=ball.m,
             h=cushion.height,
         )
-        s = pooltool.sliding
+        s = pt.sliding
 
         ball.set(rvw, s, t=self.time)
         ball.update_next_transition_event()
@@ -117,7 +117,7 @@ class StickBallCollision(Collision):
 
     def __init__(self, cue_stick, ball, t=None):
         self.state_start = ball.s
-        self.state_end = pooltool.sliding
+        self.state_end = pt.sliding
 
         Collision.__init__(self, body1=cue_stick, body2=ball, t=t)
 
@@ -128,9 +128,9 @@ class StickBallCollision(Collision):
         v, w = physics.cue_strike(ball.m, cue_stick.M, ball.R, cue_stick.V0, cue_stick.phi, cue_stick.theta, cue_stick.a, cue_stick.b)
         rvw = np.array([ball.rvw[0], v, w])
 
-        s = (pooltool.rolling
-             if abs(np.sum(physics.get_rel_velocity(rvw, ball.R))) <= pooltool.tol
-             else pooltool.sliding)
+        s = (pt.rolling
+             if abs(np.sum(physics.get_rel_velocity(rvw, ball.R))) <= pt.tol
+             else pt.sliding)
 
         ball.set(rvw, s)
         ball.update_next_transition_event()
@@ -141,7 +141,7 @@ class BallPocketCollision(Collision):
 
     def __init__(self, ball, pocket, t=None):
         self.state_start = ball.s
-        self.state_end = pooltool.pocketed
+        self.state_end = pt.pocketed
 
         Collision.__init__(self, body1=ball, body2=pocket, t=t)
 
@@ -178,7 +178,7 @@ class SpinningStationaryTransition(Transition):
 
     def __init__(self, ball, t=None):
         Transition.__init__(self, ball, t=t)
-        self.state_start, self.state_end = pooltool.spinning, pooltool.stationary
+        self.state_start, self.state_end = pt.spinning, pt.stationary
 
 
 class RollingStationaryTransition(Transition):
@@ -186,7 +186,7 @@ class RollingStationaryTransition(Transition):
 
     def __init__(self, ball, t=None):
         Transition.__init__(self, ball, t=t)
-        self.state_start, self.state_end = pooltool.rolling, pooltool.stationary
+        self.state_start, self.state_end = pt.rolling, pt.stationary
 
 
 class RollingSpinningTransition(Transition):
@@ -194,7 +194,7 @@ class RollingSpinningTransition(Transition):
 
     def __init__(self, ball, t=None):
         Transition.__init__(self, ball, t=t)
-        self.state_start, self.state_end = pooltool.rolling, pooltool.spinning
+        self.state_start, self.state_end = pt.rolling, pt.spinning
 
 
 class SlidingRollingTransition(Transition):
@@ -202,7 +202,7 @@ class SlidingRollingTransition(Transition):
 
     def __init__(self, ball, t=None):
         Transition.__init__(self, ball, t=t)
-        self.state_start, self.state_end = pooltool.sliding, pooltool.rolling
+        self.state_start, self.state_end = pt.sliding, pt.rolling
 
 
 class NonEvent(Event):

--- a/pooltool/events.py
+++ b/pooltool/events.py
@@ -1,8 +1,8 @@
 #! /usr/bin/env python
 
-import pooltool as pt
 import pooltool.utils as utils
 import pooltool.physics as physics
+import pooltool.constants as c
 
 import numpy as np
 
@@ -64,10 +64,10 @@ class BallBallCollision(Collision):
 
     def __init__(self, ball1, ball2, t=None):
         self.ball1_state_start = ball1.s
-        self.ball1_state_end = pt.sliding
+        self.ball1_state_end = c.sliding
 
         self.ball2_state_start = ball2.s
-        self.ball2_state_end = pt.sliding
+        self.ball2_state_end = c.sliding
 
         Collision.__init__(self, body1=ball1, body2=ball2, t=t)
 
@@ -76,7 +76,7 @@ class BallBallCollision(Collision):
         ball1, ball2 = self.agents
 
         rvw1, rvw2 = physics.resolve_ball_ball_collision(ball1.rvw, ball2.rvw)
-        s1, s2 = pt.sliding, pt.sliding
+        s1, s2 = c.sliding, c.sliding
 
         ball1.set(rvw1, s1, t=self.time)
         ball1.update_next_transition_event()
@@ -90,7 +90,7 @@ class BallCushionCollision(Collision):
 
     def __init__(self, ball, cushion, t=None):
         self.state_start = ball.s
-        self.state_end = pt.sliding
+        self.state_end = c.sliding
 
         Collision.__init__(self, body1=ball, body2=cushion, t=t)
 
@@ -106,7 +106,7 @@ class BallCushionCollision(Collision):
             m=ball.m,
             h=cushion.height,
         )
-        s = pt.sliding
+        s = c.sliding
 
         ball.set(rvw, s, t=self.time)
         ball.update_next_transition_event()
@@ -117,7 +117,7 @@ class StickBallCollision(Collision):
 
     def __init__(self, cue_stick, ball, t=None):
         self.state_start = ball.s
-        self.state_end = pt.sliding
+        self.state_end = c.sliding
 
         Collision.__init__(self, body1=cue_stick, body2=ball, t=t)
 
@@ -128,9 +128,9 @@ class StickBallCollision(Collision):
         v, w = physics.cue_strike(ball.m, cue_stick.M, ball.R, cue_stick.V0, cue_stick.phi, cue_stick.theta, cue_stick.a, cue_stick.b)
         rvw = np.array([ball.rvw[0], v, w])
 
-        s = (pt.rolling
-             if abs(np.sum(physics.get_rel_velocity(rvw, ball.R))) <= pt.tol
-             else pt.sliding)
+        s = (c.rolling
+             if abs(np.sum(physics.get_rel_velocity(rvw, ball.R))) <= c.tol
+             else c.sliding)
 
         ball.set(rvw, s)
         ball.update_next_transition_event()
@@ -141,7 +141,7 @@ class BallPocketCollision(Collision):
 
     def __init__(self, ball, pocket, t=None):
         self.state_start = ball.s
-        self.state_end = pt.pocketed
+        self.state_end = c.pocketed
 
         Collision.__init__(self, body1=ball, body2=pocket, t=t)
 
@@ -178,7 +178,7 @@ class SpinningStationaryTransition(Transition):
 
     def __init__(self, ball, t=None):
         Transition.__init__(self, ball, t=t)
-        self.state_start, self.state_end = pt.spinning, pt.stationary
+        self.state_start, self.state_end = c.spinning, c.stationary
 
 
 class RollingStationaryTransition(Transition):
@@ -186,7 +186,7 @@ class RollingStationaryTransition(Transition):
 
     def __init__(self, ball, t=None):
         Transition.__init__(self, ball, t=t)
-        self.state_start, self.state_end = pt.rolling, pt.stationary
+        self.state_start, self.state_end = c.rolling, c.stationary
 
 
 class RollingSpinningTransition(Transition):
@@ -194,7 +194,7 @@ class RollingSpinningTransition(Transition):
 
     def __init__(self, ball, t=None):
         Transition.__init__(self, ball, t=t)
-        self.state_start, self.state_end = pt.rolling, pt.spinning
+        self.state_start, self.state_end = c.rolling, c.spinning
 
 
 class SlidingRollingTransition(Transition):
@@ -202,7 +202,7 @@ class SlidingRollingTransition(Transition):
 
     def __init__(self, ball, t=None):
         Transition.__init__(self, ball, t=t)
-        self.state_start, self.state_end = pt.sliding, pt.rolling
+        self.state_start, self.state_end = c.sliding, c.rolling
 
 
 class NonEvent(Event):

--- a/pooltool/evolution.py
+++ b/pooltool/evolution.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+import pooltool as pt
 import pooltool.terminal as terminal
 
 from pooltool.events import *
@@ -179,10 +180,10 @@ class EvolveShotEventBased(EvolveShot):
                 if i >= j:
                     continue
 
-                if ball1.s == pooltool.pocketed or ball2.s == pooltool.pocketed:
+                if ball1.s == pt.pocketed or ball2.s == pt.pocketed:
                     continue
 
-                if ball1.s in pooltool.nontranslating and ball2.s in pooltool.nontranslating:
+                if ball1.s in pt.nontranslating and ball2.s in pt.nontranslating:
                     continue
 
                 dtau_E = physics.get_ball_ball_collision_time(
@@ -190,8 +191,8 @@ class EvolveShotEventBased(EvolveShot):
                     rvw2=ball2.rvw,
                     s1=ball1.s,
                     s2=ball2.s,
-                    mu1=(ball1.u_s if ball1.s == pooltool.sliding else ball1.u_r),
-                    mu2=(ball2.u_s if ball2.s == pooltool.sliding else ball2.u_r),
+                    mu1=(ball1.u_s if ball1.s == pt.sliding else ball1.u_r),
+                    mu2=(ball2.u_s if ball2.s == pt.sliding else ball2.u_r),
                     m1=ball1.m,
                     m2=ball2.m,
                     g1=ball1.g,
@@ -215,7 +216,7 @@ class EvolveShotEventBased(EvolveShot):
         involved_agents = tuple([DummyBall(), NonObject()])
 
         for ball in self.balls.values():
-            if ball.s in pooltool.nontranslating:
+            if ball.s in pt.nontranslating:
                 continue
 
             for cushion in self.table.cushion_segments['linear'].values():
@@ -227,7 +228,7 @@ class EvolveShotEventBased(EvolveShot):
                     l0=cushion.l0,
                     p1=cushion.p1,
                     p2=cushion.p2,
-                    mu=(ball.u_s if ball.s == pooltool.sliding else ball.u_r),
+                    mu=(ball.u_s if ball.s == pt.sliding else ball.u_r),
                     m=ball.m,
                     g=ball.g,
                     R=ball.R
@@ -244,7 +245,7 @@ class EvolveShotEventBased(EvolveShot):
                     a=cushion.a,
                     b=cushion.b,
                     r=cushion.radius,
-                    mu=(ball.u_s if ball.s == pooltool.sliding else ball.u_r),
+                    mu=(ball.u_s if ball.s == pt.sliding else ball.u_r),
                     m=ball.m,
                     g=ball.g,
                     R=ball.R
@@ -266,7 +267,7 @@ class EvolveShotEventBased(EvolveShot):
         involved_agents = tuple([DummyBall(), NonObject()])
 
         for ball in self.balls.values():
-            if ball.s in pooltool.nontranslating:
+            if ball.s in pt.nontranslating:
                 continue
 
             for pocket in self.table.pockets.values():
@@ -276,7 +277,7 @@ class EvolveShotEventBased(EvolveShot):
                     a=pocket.a,
                     b=pocket.b,
                     r=pocket.radius,
-                    mu=(ball.u_s if ball.s == pooltool.sliding else ball.u_r),
+                    mu=(ball.u_s if ball.s == pt.sliding else ball.u_r),
                     m=ball.m,
                     g=ball.g,
                     R=ball.R
@@ -315,7 +316,7 @@ class EvolveShotDiscreteTime(EvolveShot):
             if t_final is not None and self.t >= t_final:
                 break
 
-            if self.get_system_energy() < pooltool.tol:
+            if self.get_system_energy() < pt.tol:
                 break
 
             steps += 1
@@ -339,7 +340,7 @@ class EvolveShotDiscreteTime(EvolveShot):
                 if i >= j:
                     continue
 
-                if ball1.s in pooltool.nontranslating and ball2.s in pooltool.nontranslating:
+                if ball1.s in pt.nontranslating and ball2.s in pt.nontranslating:
                     continue
 
                 if physics.is_overlapping(ball1.rvw, ball2.rvw, ball1.R, ball2.R):

--- a/pooltool/evolution.py
+++ b/pooltool/evolution.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
-import pooltool as pt
 import pooltool.terminal as terminal
+import pooltool.constants as c
 
 from pooltool.events import *
 from pooltool.system import System, SystemHistory, SystemRender
@@ -180,10 +180,10 @@ class EvolveShotEventBased(EvolveShot):
                 if i >= j:
                     continue
 
-                if ball1.s == pt.pocketed or ball2.s == pt.pocketed:
+                if ball1.s == c.pocketed or ball2.s == c.pocketed:
                     continue
 
-                if ball1.s in pt.nontranslating and ball2.s in pt.nontranslating:
+                if ball1.s in c.nontranslating and ball2.s in c.nontranslating:
                     continue
 
                 dtau_E = physics.get_ball_ball_collision_time(
@@ -191,8 +191,8 @@ class EvolveShotEventBased(EvolveShot):
                     rvw2=ball2.rvw,
                     s1=ball1.s,
                     s2=ball2.s,
-                    mu1=(ball1.u_s if ball1.s == pt.sliding else ball1.u_r),
-                    mu2=(ball2.u_s if ball2.s == pt.sliding else ball2.u_r),
+                    mu1=(ball1.u_s if ball1.s == c.sliding else ball1.u_r),
+                    mu2=(ball2.u_s if ball2.s == c.sliding else ball2.u_r),
                     m1=ball1.m,
                     m2=ball2.m,
                     g1=ball1.g,
@@ -216,7 +216,7 @@ class EvolveShotEventBased(EvolveShot):
         involved_agents = tuple([DummyBall(), NonObject()])
 
         for ball in self.balls.values():
-            if ball.s in pt.nontranslating:
+            if ball.s in c.nontranslating:
                 continue
 
             for cushion in self.table.cushion_segments['linear'].values():
@@ -228,7 +228,7 @@ class EvolveShotEventBased(EvolveShot):
                     l0=cushion.l0,
                     p1=cushion.p1,
                     p2=cushion.p2,
-                    mu=(ball.u_s if ball.s == pt.sliding else ball.u_r),
+                    mu=(ball.u_s if ball.s == c.sliding else ball.u_r),
                     m=ball.m,
                     g=ball.g,
                     R=ball.R
@@ -245,7 +245,7 @@ class EvolveShotEventBased(EvolveShot):
                     a=cushion.a,
                     b=cushion.b,
                     r=cushion.radius,
-                    mu=(ball.u_s if ball.s == pt.sliding else ball.u_r),
+                    mu=(ball.u_s if ball.s == c.sliding else ball.u_r),
                     m=ball.m,
                     g=ball.g,
                     R=ball.R
@@ -267,7 +267,7 @@ class EvolveShotEventBased(EvolveShot):
         involved_agents = tuple([DummyBall(), NonObject()])
 
         for ball in self.balls.values():
-            if ball.s in pt.nontranslating:
+            if ball.s in c.nontranslating:
                 continue
 
             for pocket in self.table.pockets.values():
@@ -277,7 +277,7 @@ class EvolveShotEventBased(EvolveShot):
                     a=pocket.a,
                     b=pocket.b,
                     r=pocket.radius,
-                    mu=(ball.u_s if ball.s == pt.sliding else ball.u_r),
+                    mu=(ball.u_s if ball.s == c.sliding else ball.u_r),
                     m=ball.m,
                     g=ball.g,
                     R=ball.R
@@ -316,7 +316,7 @@ class EvolveShotDiscreteTime(EvolveShot):
             if t_final is not None and self.t >= t_final:
                 break
 
-            if self.get_system_energy() < pt.tol:
+            if self.get_system_energy() < c.tol:
                 break
 
             steps += 1
@@ -340,7 +340,7 @@ class EvolveShotDiscreteTime(EvolveShot):
                 if i >= j:
                     continue
 
-                if ball1.s in pt.nontranslating and ball2.s in pt.nontranslating:
+                if ball1.s in c.nontranslating and ball2.s in c.nontranslating:
                     continue
 
                 if physics.is_overlapping(ball1.rvw, ball2.rvw, ball1.R, ball2.R):

--- a/pooltool/games/__init__.py
+++ b/pooltool/games/__init__.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-import pooltool
+import pooltool as pt
 import pooltool.ani as ani
 
 from pooltool.terminal import Timer
@@ -112,7 +112,7 @@ class Game(ABC):
         """
         R = shot.balls[ball_id].R
         shot.balls[ball_id].rvw[0] = [x, y, z]
-        shot.balls[ball_id].s = pooltool.stationary
+        shot.balls[ball_id].s = pt.stationary
 
 
     def advance(self, shot):

--- a/pooltool/games/__init__.py
+++ b/pooltool/games/__init__.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
-import pooltool as pt
 import pooltool.ani as ani
+import pooltool.constants as c
 
 from pooltool.terminal import Timer
 
@@ -112,7 +112,7 @@ class Game(ABC):
         """
         R = shot.balls[ball_id].R
         shot.balls[ball_id].rvw[0] = [x, y, z]
-        shot.balls[ball_id].s = pt.stationary
+        shot.balls[ball_id].s = c.stationary
 
 
     def advance(self, shot):

--- a/pooltool/games/eight_ball.py
+++ b/pooltool/games/eight_ball.py
@@ -1,8 +1,8 @@
 #! /usr/bin/env python
 
-import pooltool as pt
 import pooltool.ani as ani
 import pooltool.events as e
+import pooltool.constants as c
 
 from pooltool.games import Player, Game
 from pooltool.objects import DummyBall
@@ -138,7 +138,7 @@ class EightBall(Game):
 
 
     def is_cue_pocketed(self, shot):
-        return True if shot.balls['cue'].s == pt.pocketed else False
+        return True if shot.balls['cue'].s == c.pocketed else False
 
 
     def is_cushion_after_first_contact(self, shot):
@@ -223,7 +223,7 @@ class EightBall(Game):
                 player.target_balls = self.solids + self.stripes
 
             states = [ball.s for ball in shot.balls.values() if ball.id in player.target_balls]
-            if all([state == pt.pocketed for state in states]):
+            if all([state == c.pocketed for state in states]):
                 player.target_balls.append('8')
 
 

--- a/pooltool/games/eight_ball.py
+++ b/pooltool/games/eight_ball.py
@@ -1,9 +1,8 @@
 #! /usr/bin/env python
 
-import pooltool
+import pooltool as pt
 import pooltool.ani as ani
 import pooltool.events as e
-import pooltool.ani.utils as autils
 
 from pooltool.games import Player, Game
 from pooltool.objects import DummyBall
@@ -139,7 +138,7 @@ class EightBall(Game):
 
 
     def is_cue_pocketed(self, shot):
-        return True if shot.balls['cue'].s == pooltool.pocketed else False
+        return True if shot.balls['cue'].s == pt.pocketed else False
 
 
     def is_cushion_after_first_contact(self, shot):
@@ -224,7 +223,7 @@ class EightBall(Game):
                 player.target_balls = self.solids + self.stripes
 
             states = [ball.s for ball in shot.balls.values() if ball.id in player.target_balls]
-            if all([state == pooltool.pocketed for state in states]):
+            if all([state == pt.pocketed for state in states]):
                 player.target_balls.append('8')
 
 

--- a/pooltool/games/eight_ball.py
+++ b/pooltool/games/eight_ball.py
@@ -38,11 +38,7 @@ class EightBall(Game):
 
 
     def setup_initial_layout(self, table, ball_kwargs={}):
-        self.layout = EightBallRack(ordered=True, **ball_kwargs)
-        self.layout.center_by_table(table)
-
-        # get the cueing ball
-        self.layout.get_balls_dict()
+        self.balls = EightBallRack(table=table, ordered=True, **ball_kwargs).balls
 
 
     def set_initial_cueing_ball(self, balls):

--- a/pooltool/games/nine_ball.py
+++ b/pooltool/games/nine_ball.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
-import pooltool as pt
 import pooltool.events as e
+import pooltool.constants as c
 
 from pooltool.games import Player, Game
 from pooltool.objects import DummyBall
@@ -109,7 +109,7 @@ class NineBall(Game):
         for ball in shot.balls.values():
             if ball.id == 'cue':
                 continue
-            if ball.history.s[0] == pt.pocketed:
+            if ball.history.s[0] == c.pocketed:
                 continue
             if int(ball.id) < int(lowest.id):
                 lowest = ball
@@ -123,7 +123,7 @@ class NineBall(Game):
         for ball in shot.balls.values():
             if ball.id == 'cue':
                 continue
-            if ball.history.s[0] == pt.pocketed:
+            if ball.history.s[0] == c.pocketed:
                 continue
             if int(ball.id) > int(highest.id):
                 highest = ball
@@ -161,7 +161,7 @@ class NineBall(Game):
 
 
     def is_cue_pocketed(self, shot):
-        return True if shot.balls['cue'].s == pt.pocketed else False
+        return True if shot.balls['cue'].s == c.pocketed else False
 
 
     def is_cushion_after_first_contact(self, shot):

--- a/pooltool/games/nine_ball.py
+++ b/pooltool/games/nine_ball.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-import pooltool
+import pooltool as pt
 import pooltool.events as e
 
 from pooltool.games import Player, Game
@@ -109,7 +109,7 @@ class NineBall(Game):
         for ball in shot.balls.values():
             if ball.id == 'cue':
                 continue
-            if ball.history.s[0] == pooltool.pocketed:
+            if ball.history.s[0] == pt.pocketed:
                 continue
             if int(ball.id) < int(lowest.id):
                 lowest = ball
@@ -123,7 +123,7 @@ class NineBall(Game):
         for ball in shot.balls.values():
             if ball.id == 'cue':
                 continue
-            if ball.history.s[0] == pooltool.pocketed:
+            if ball.history.s[0] == pt.pocketed:
                 continue
             if int(ball.id) > int(highest.id):
                 highest = ball
@@ -161,7 +161,7 @@ class NineBall(Game):
 
 
     def is_cue_pocketed(self, shot):
-        return True if shot.balls['cue'].s == pooltool.pocketed else False
+        return True if shot.balls['cue'].s == pt.pocketed else False
 
 
     def is_cushion_after_first_contact(self, shot):

--- a/pooltool/games/nine_ball.py
+++ b/pooltool/games/nine_ball.py
@@ -22,11 +22,7 @@ class NineBall(Game):
 
 
     def setup_initial_layout(self, table, ball_kwargs={}):
-        self.layout = NineBallRack(ordered=True, **ball_kwargs)
-        self.layout.center_by_table(table)
-
-        # get the cueing ball
-        self.layout.get_balls_dict()
+        self.balls = NineBallRack(table=table, ordered=True, **ball_kwargs).balls
 
 
     def set_initial_cueing_ball(self, balls):

--- a/pooltool/games/sandbox.py
+++ b/pooltool/games/sandbox.py
@@ -20,19 +20,16 @@ class Sandbox(Game):
         Game.__init__(self)
         self.create_players(1)
 
+
     def start(self):
-        self.active_player.ball_in_hand = [ball.id for ball in self.layout.get_balls_dict().values()]
+        self.active_player.ball_in_hand = [ball_id for ball_id in self.balls]
         for player in self.players:
-            player.can_cue = [ball.id for ball in self.layout.get_balls_dict().values()]
-            player.target_balls = [ball.id for ball in self.layout.get_balls_dict().values()]
+            player.can_cue = [ball_id for ball_id in self.balls]
+            player.target_balls = [ball_id for ball_id in self.balls]
 
 
     def setup_initial_layout(self, table, ball_kwargs={}):
-        self.layout = NineBallRack(ordered=True, **ball_kwargs)
-        self.layout.center_by_table(table)
-
-        # get the cueing ball
-        self.layout.get_balls_dict()
+        self.balls = NineBallRack(table, ordered=True, **ball_kwargs).balls
 
 
     def set_initial_cueing_ball(self, balls):

--- a/pooltool/games/sandbox.py
+++ b/pooltool/games/sandbox.py
@@ -1,8 +1,8 @@
 #! /usr/bin/env python
 
-import pooltool as pt
 import pooltool.ani as ani
 import pooltool.events as e
+import pooltool.constants as c
 
 from pooltool.games import Player, Game
 from pooltool.objects import DummyBall
@@ -52,7 +52,7 @@ class Sandbox(Game):
 
 
     def respot_balls(self, shot):
-        if shot.balls['cue'].s == pt.pocketed:
+        if shot.balls['cue'].s == c.pocketed:
             self.respot(shot, 'cue', shot.table.w/2, shot.table.l*1/4, shot.balls['cue'].R)
 
 

--- a/pooltool/games/sandbox.py
+++ b/pooltool/games/sandbox.py
@@ -1,9 +1,8 @@
 #! /usr/bin/env python
 
-import pooltool
+import pooltool as pt
 import pooltool.ani as ani
 import pooltool.events as e
-import pooltool.ani.utils as autils
 
 from pooltool.games import Player, Game
 from pooltool.objects import DummyBall
@@ -53,7 +52,7 @@ class Sandbox(Game):
 
 
     def respot_balls(self, shot):
-        if shot.balls['cue'].s == pooltool.pocketed:
+        if shot.balls['cue'].s == pt.pocketed:
             self.respot(shot, 'cue', shot.table.w/2, shot.table.l*1/4, shot.balls['cue'].R)
 
 

--- a/pooltool/layouts.py
+++ b/pooltool/layouts.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-import pooltool
+import pooltool as pt
 
 from pooltool.objects.ball import Ball
 
@@ -12,7 +12,7 @@ class NineBallRack(object):
         self.balls = [Ball(str(i), **ball_kwargs) for i in range(1,10)]
         self.radius = max([ball.R for ball in self.balls])
         self.spacer = spacing_factor * self.radius
-        self.eff_radius = self.radius + self.spacer + pooltool.tol
+        self.eff_radius = self.radius + self.spacer + pt.tol
 
         if not ordered:
             self.balls = np.random.choice(self.balls, replace=False, size=len(self.balls))
@@ -71,7 +71,7 @@ class EightBallRack(object):
         self.balls = [Ball(str(i), **ball_kwargs) for i in range(1,16)]
         self.radius = max([ball.R for ball in self.balls])
         self.spacer = spacing_factor * self.radius
-        self.eff_radius = self.radius + self.spacer + pooltool.tol
+        self.eff_radius = self.radius + self.spacer + pt.tol
 
         if not ordered:
             self.balls = np.random.choice(self.balls, replace=False, size=len(self.balls))

--- a/pooltool/layouts.py
+++ b/pooltool/layouts.py
@@ -6,7 +6,11 @@ from pooltool.objects.ball import Ball
 
 import numpy as np
 
-class NineBallRack(object):
+
+class Rack(object):
+    pass
+
+class NineBallRack(Rack):
     """Arrange a list of balls into 9-ball break configuration"""
     def __init__(self, spacing_factor=1e-3, ordered=False, **ball_kwargs):
         self.balls = [Ball(str(i), **ball_kwargs) for i in range(1,10)]
@@ -65,7 +69,7 @@ class NineBallRack(object):
         return {str(ball.id): ball for ball in self.balls}
 
 
-class EightBallRack(object):
+class EightBallRack(Rack):
     """Arrange a list of balls into 8-ball break configuration"""
     def __init__(self, spacing_factor=1e-3, ordered=False, **ball_kwargs):
         self.balls = [Ball(str(i), **ball_kwargs) for i in range(1,16)]

--- a/pooltool/layouts.py
+++ b/pooltool/layouts.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-import pooltool as pt
+import pooltool.constants as c
 
 from pooltool.objects.ball import Ball
 
@@ -12,7 +12,7 @@ class NineBallRack(object):
         self.balls = [Ball(str(i), **ball_kwargs) for i in range(1,10)]
         self.radius = max([ball.R for ball in self.balls])
         self.spacer = spacing_factor * self.radius
-        self.eff_radius = self.radius + self.spacer + pt.tol
+        self.eff_radius = self.radius + self.spacer + c.tol
 
         if not ordered:
             self.balls = np.random.choice(self.balls, replace=False, size=len(self.balls))
@@ -71,7 +71,7 @@ class EightBallRack(object):
         self.balls = [Ball(str(i), **ball_kwargs) for i in range(1,16)]
         self.radius = max([ball.R for ball in self.balls])
         self.spacer = spacing_factor * self.radius
-        self.eff_radius = self.radius + self.spacer + pt.tol
+        self.eff_radius = self.radius + self.spacer + c.tol
 
         if not ordered:
             self.balls = np.random.choice(self.balls, replace=False, size=len(self.balls))

--- a/pooltool/layouts.py
+++ b/pooltool/layouts.py
@@ -6,23 +6,43 @@ from pooltool.objects.ball import Ball
 
 import numpy as np
 
+from abc import ABC, abstractmethod
 
-class Rack(object):
-    pass
+
+class Rack(ABC):
+    def __init__(self, table):
+        self.arrange()
+        self.center_by_table(table)
+        self.balls = self.get_balls_dict()
+
+
+    def get_balls_dict(self):
+        return {str(ball.id): ball for ball in self.balls}
+
+
+    @abstractmethod
+    def arrange(self):
+        pass
+
+
+    @abstractmethod
+    def center_by_table(self):
+        pass
+
 
 class NineBallRack(Rack):
     """Arrange a list of balls into 9-ball break configuration"""
-    def __init__(self, spacing_factor=1e-3, ordered=False, **ball_kwargs):
+    def __init__(self, table, spacing_factor=1e-3, ordered=False, **ball_kwargs):
         self.balls = [Ball(str(i), **ball_kwargs) for i in range(1,10)]
         self.radius = max([ball.R for ball in self.balls])
         self.spacer = spacing_factor * self.radius
         self.eff_radius = self.radius + self.spacer + c.tol
 
         if not ordered:
-            self.balls = np.random.choice(self.balls, replace=False, size=len(self.balls))
+            self.balls = list(np.random.choice(self.balls, replace=False, size=len(self.balls)))
 
         self.balls.append(Ball('cue', **ball_kwargs))
-        self.arrange()
+        Rack.__init__(self, table)
 
 
     def wiggle(self, xyz):
@@ -65,23 +85,19 @@ class NineBallRack(Rack):
         self.balls[-1].rvw[0] = [table.center[0] + 0.2, table.l/4, self.balls[-1].R]
 
 
-    def get_balls_dict(self):
-        return {str(ball.id): ball for ball in self.balls}
-
-
 class EightBallRack(Rack):
     """Arrange a list of balls into 8-ball break configuration"""
-    def __init__(self, spacing_factor=1e-3, ordered=False, **ball_kwargs):
+    def __init__(self, table, spacing_factor=1e-3, ordered=False, **ball_kwargs):
         self.balls = [Ball(str(i), **ball_kwargs) for i in range(1,16)]
         self.radius = max([ball.R for ball in self.balls])
         self.spacer = spacing_factor * self.radius
         self.eff_radius = self.radius + self.spacer + c.tol
 
         if not ordered:
-            self.balls = np.random.choice(self.balls, replace=False, size=len(self.balls))
+            self.balls = list(np.random.choice(self.balls, replace=False, size=len(self.balls)))
 
         self.balls.append(Ball('cue', **ball_kwargs))
-        self.arrange()
+        Rack.__init__(self, table)
 
 
     def wiggle(self, xyz):
@@ -130,7 +146,10 @@ class EightBallRack(Rack):
         self.balls[-1].rvw[0] = [table.center[0] + 0.2, table.l/4, self.balls[-1].R]
 
 
-    def get_balls_dict(self):
-        return {str(ball.id): ball for ball in self.balls}
+def get_nine_ball_rack(*args, **kwargs):
+    return NineBallRack(*args, **kwargs).balls
 
+
+def get_eight_ball_rack(*args, **kwargs):
+    return EightBallRack(*args, **kwargs).balls
 

--- a/pooltool/objects/__init__.py
+++ b/pooltool/objects/__init__.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-import pooltool
+import pooltool as pt
 
 from abc import ABC, abstractmethod
 
@@ -20,7 +20,7 @@ class NonObject(Object):
 
 
 class DummyBall(NonObject):
-    s = pooltool.stationary
+    s = pt.stationary
     def __init__(self, ball_id='NA'):
         self.id = ball_id
 

--- a/pooltool/objects/__init__.py
+++ b/pooltool/objects/__init__.py
@@ -1,9 +1,8 @@
 #! /usr/bin/env python
 
-import pooltool as pt
+import pooltool.constants as c
 
 from abc import ABC, abstractmethod
-
 
 class Object(object):
     object_type = None
@@ -20,7 +19,7 @@ class NonObject(Object):
 
 
 class DummyBall(NonObject):
-    s = pt.stationary
+    s = c.stationary
     def __init__(self, ball_id='NA'):
         self.id = ball_id
 
@@ -103,4 +102,8 @@ class Render(ABC):
 
         self.rendered = True
 
+
+from .ball import *
+from .cue import *
+from .table import *
 

--- a/pooltool/objects/__init__.py
+++ b/pooltool/objects/__init__.py
@@ -103,7 +103,3 @@ class Render(ABC):
         self.rendered = True
 
 
-from .ball import *
-from .cue import *
-from .table import *
-

--- a/pooltool/objects/ball.py
+++ b/pooltool/objects/ball.py
@@ -3,17 +3,20 @@
 import pooltool.ani as ani
 import pooltool.physics as physics
 import pooltool.ani.utils as autils
+import pooltool.constants as c
 
 from pooltool.utils import panda_path
 from pooltool.error import ConfigError
 from pooltool.events import *
-from pooltool.objects import *
+from pooltool.objects import Render, Object
 
 import numpy as np
 
 from pathlib import Path
 from panda3d.core import *
 from direct.interval.IntervalGlobal import *
+
+__all__ = ['Ball']
 
 class BallRender(Render):
     def __init__(self):
@@ -265,18 +268,18 @@ class Ball(Object, BallRender, Events):
         self.id = ball_id
 
         # physical properties
-        self.m = m or pt.m
-        self.R = R or pt.R
+        self.m = m or c.m
+        self.R = R or c.R
         self.I = 2/5 * self.m * self.R**2
-        self.g = g or pt.g
+        self.g = g or c.g
 
         # felt properties
-        self.u_s = u_s or pt.u_s
-        self.u_r = u_r or pt.u_r
-        self.u_sp = u_sp or pt.u_sp
+        self.u_s = u_s or c.u_s
+        self.u_r = u_r or c.u_r
+        self.u_sp = u_sp or c.u_sp
 
         self.t = 0
-        self.s = pt.stationary
+        self.s = c.stationary
         self.rvw = np.array([[np.nan, np.nan, np.nan],  # positions (r)
                              [0,      0,      0     ],  # velocities (v)
                              [0,      0,      0     ]]) # angular velocities (w)
@@ -303,14 +306,14 @@ class Ball(Object, BallRender, Events):
 
 
     def update_next_transition_event(self):
-        if self.s == pt.stationary or self.s == pt.pocketed:
+        if self.s == c.stationary or self.s == c.pocketed:
             self.next_transition_event = NonEvent(t = np.inf)
 
-        elif self.s == pt.spinning:
+        elif self.s == c.spinning:
             dtau_E = physics.get_spin_time(self.rvw, self.R, self.u_sp, self.g)
             self.next_transition_event = SpinningStationaryTransition(self, t=(self.t + dtau_E))
 
-        elif self.s == pt.rolling:
+        elif self.s == c.rolling:
             dtau_E_spin = physics.get_spin_time(self.rvw, self.R, self.u_sp, self.g)
             dtau_E_roll = physics.get_roll_time(self.rvw, self.u_r, self.g)
 
@@ -319,7 +322,7 @@ class Ball(Object, BallRender, Events):
             else:
                 self.next_transition_event = RollingStationaryTransition(self, t=(self.t + dtau_E_roll))
 
-        elif self.s == pt.sliding:
+        elif self.s == c.sliding:
             dtau_E = physics.get_slide_time(self.rvw, self.R, self.u_s, self.g)
             self.next_transition_event = SlidingRollingTransition(self, t=(self.t + dtau_E))
 

--- a/pooltool/objects/ball.py
+++ b/pooltool/objects/ball.py
@@ -265,18 +265,18 @@ class Ball(Object, BallRender, Events):
         self.id = ball_id
 
         # physical properties
-        self.m = m or pooltool.m
-        self.R = R or pooltool.R
+        self.m = m or pt.m
+        self.R = R or pt.R
         self.I = 2/5 * self.m * self.R**2
-        self.g = g or pooltool.g
+        self.g = g or pt.g
 
         # felt properties
-        self.u_s = u_s or pooltool.u_s
-        self.u_r = u_r or pooltool.u_r
-        self.u_sp = u_sp or pooltool.u_sp
+        self.u_s = u_s or pt.u_s
+        self.u_r = u_r or pt.u_r
+        self.u_sp = u_sp or pt.u_sp
 
         self.t = 0
-        self.s = pooltool.stationary
+        self.s = pt.stationary
         self.rvw = np.array([[np.nan, np.nan, np.nan],  # positions (r)
                              [0,      0,      0     ],  # velocities (v)
                              [0,      0,      0     ]]) # angular velocities (w)
@@ -303,14 +303,14 @@ class Ball(Object, BallRender, Events):
 
 
     def update_next_transition_event(self):
-        if self.s == pooltool.stationary or self.s == pooltool.pocketed:
+        if self.s == pt.stationary or self.s == pt.pocketed:
             self.next_transition_event = NonEvent(t = np.inf)
 
-        elif self.s == pooltool.spinning:
+        elif self.s == pt.spinning:
             dtau_E = physics.get_spin_time(self.rvw, self.R, self.u_sp, self.g)
             self.next_transition_event = SpinningStationaryTransition(self, t=(self.t + dtau_E))
 
-        elif self.s == pooltool.rolling:
+        elif self.s == pt.rolling:
             dtau_E_spin = physics.get_spin_time(self.rvw, self.R, self.u_sp, self.g)
             dtau_E_roll = physics.get_roll_time(self.rvw, self.u_r, self.g)
 
@@ -319,7 +319,7 @@ class Ball(Object, BallRender, Events):
             else:
                 self.next_transition_event = RollingStationaryTransition(self, t=(self.t + dtau_E_roll))
 
-        elif self.s == pooltool.sliding:
+        elif self.s == pt.sliding:
             dtau_E = physics.get_slide_time(self.rvw, self.R, self.u_s, self.g)
             self.next_transition_event = SlidingRollingTransition(self, t=(self.t + dtau_E))
 

--- a/pooltool/objects/cue.py
+++ b/pooltool/objects/cue.py
@@ -25,7 +25,7 @@ class CueRender(Render):
         self.stroke_time = []
 
 
-    def init_model(self, R=pooltool.R):
+    def init_model(self, R=pt.R):
         path = utils.panda_path(ani.model_dir / 'cue' / 'cue.glb')
         cue_stick_model = loader.loadModel(path)
         cue_stick_model.setName('cue_stick_model')
@@ -259,8 +259,8 @@ class CueRender(Render):
 class Cue(Object, CueRender):
     object_type = 'cue_stick'
 
-    def __init__(self, M=pooltool.M, length=pooltool.cue_length, tip_radius=pooltool.cue_tip_radius,
-                 butt_radius=pooltool.cue_butt_radius, cue_id='cue_stick', brand=None):
+    def __init__(self, M=pt.M, length=pt.cue_length, tip_radius=pt.cue_tip_radius,
+                 butt_radius=pt.cue_butt_radius, cue_id='cue_stick', brand=None):
 
         self.id = cue_id
         self.M = M

--- a/pooltool/objects/cue.py
+++ b/pooltool/objects/cue.py
@@ -263,7 +263,7 @@ class Cue(Object, CueRender):
     object_type = 'cue_stick'
 
     def __init__(self, M=c.M, length=c.cue_length, tip_radius=c.cue_tip_radius,
-                 butt_radius=c.cue_butt_radius, cue_id='cue_stick', brand=None):
+                 butt_radius=c.cue_butt_radius, cueing_ball=None, cue_id='cue_stick', brand=None):
 
         self.id = cue_id
         self.M = M
@@ -272,13 +272,13 @@ class Cue(Object, CueRender):
         self.butt_radius = butt_radius
         self.brand = brand
 
-        self.V0 = None
-        self.phi = None
-        self.theta = None
-        self.a = None
-        self.b = None
+        self.V0 = 0
+        self.phi = 0
+        self.theta = 0
+        self.a = 0
+        self.b = 0
 
-        self.cueing_ball = None
+        self.cueing_ball = cueing_ball
 
         CueRender.__init__(self)
 
@@ -303,7 +303,21 @@ class Cue(Object, CueRender):
         if cueing_ball is not None: self.cueing_ball = cueing_ball
 
 
-    def strike(self, t=None):
+    def strike(self, t=None, **state_kwargs):
+        """Strike the cue ball
+
+        Parameters
+        ==========
+        t : float, None
+            The time that the collision occurs at
+
+        state_kwargs: **kwargs
+            Pass state parameters to be updated before the cue strike. Any parameters accepted by Cue.set_state
+            are permissible.
+        """
+
+        self.set_state(**state_kwargs)
+
         if (self.V0 is None or self.phi is None or self.theta is None or self.a is None or self.b is None):
             raise ValueError("Cue.strike :: Must set V0, phi, theta, a, and b")
 
@@ -313,7 +327,7 @@ class Cue(Object, CueRender):
         return event
 
 
-    def aim_at(self, pos):
+    def aim_at_pos(self, pos):
         """Set phi to aim at a 3D position
 
         Parameters
@@ -324,6 +338,18 @@ class Cue(Object, CueRender):
 
         direction = utils.angle(utils.unit_vector(np.array(pos) - self.cueing_ball.rvw[0]))
         self.set_state(phi = direction * 180/np.pi)
+
+
+    def aim_at_ball(self, ball):
+        """Set phi to aim directly at a ball
+
+        Parameters
+        ==========
+        ball : pooltool.objects.ball.Ball
+            A ball
+        """
+
+        self.aim_at_pos(ball.rvw[0])
 
 
 class CueAvoid(object):

--- a/pooltool/objects/cue.py
+++ b/pooltool/objects/cue.py
@@ -2,15 +2,18 @@
 
 import pooltool.ani as ani
 import pooltool.utils as utils
+import pooltool.constants as c
 
 from pooltool.events import StickBallCollision
-from pooltool.objects import *
+from pooltool.objects import Object, Render
 
 import numpy as np
 
 from pathlib import Path
 from panda3d.core import *
 from direct.interval.IntervalGlobal import *
+
+__all__ = ['Cue']
 
 class CueRender(Render):
     def __init__(self):
@@ -25,7 +28,7 @@ class CueRender(Render):
         self.stroke_time = []
 
 
-    def init_model(self, R=pt.R):
+    def init_model(self, R=c.R):
         path = utils.panda_path(ani.model_dir / 'cue' / 'cue.glb')
         cue_stick_model = loader.loadModel(path)
         cue_stick_model.setName('cue_stick_model')
@@ -259,8 +262,8 @@ class CueRender(Render):
 class Cue(Object, CueRender):
     object_type = 'cue_stick'
 
-    def __init__(self, M=pt.M, length=pt.cue_length, tip_radius=pt.cue_tip_radius,
-                 butt_radius=pt.cue_butt_radius, cue_id='cue_stick', brand=None):
+    def __init__(self, M=c.M, length=c.cue_length, tip_radius=c.cue_tip_radius,
+                 butt_radius=c.cue_butt_radius, cue_id='cue_stick', brand=None):
 
         self.id = cue_id
         self.M = M

--- a/pooltool/objects/table.py
+++ b/pooltool/objects/table.py
@@ -3,15 +3,21 @@
 import pooltool.ani as ani
 import pooltool.utils as utils
 import pooltool.ani.utils as autils
+import pooltool.constants as c
 
 from pooltool.error import ConfigError
 from pooltool.utils import panda_path
-from pooltool.objects import *
+from pooltool.objects import Object, Render
 
 import numpy as np
 
 from pathlib import Path
 from panda3d.core import *
+
+__all__ = [
+    'PocketTable',
+    'BilliardTable',
+]
 
 
 class TableRender(Render):
@@ -191,22 +197,22 @@ class PocketTable(Object, TableRender):
                  side_pocket_width=None, side_pocket_angle=None, side_pocket_depth=None, side_pocket_radius=None,
                  side_jaw_radius=None, table_height=None, lights_height=None, has_model=False, model_name='none'):
 
-        self.w = table_width or pt.table_width
-        self.l = table_length or pt.table_length
-        self.cushion_width = cushion_width or pt.cushion_width
-        self.cushion_height = cushion_height or pt.cushion_height
-        self.corner_pocket_width = corner_pocket_width or pt.corner_pocket_width
-        self.corner_pocket_angle = corner_pocket_angle or pt.corner_pocket_angle
-        self.corner_pocket_depth = corner_pocket_depth or pt.corner_pocket_depth
-        self.corner_pocket_radius = corner_pocket_radius or pt.corner_pocket_radius
-        self.corner_jaw_radius = corner_jaw_radius or pt.corner_jaw_radius
-        self.side_pocket_width = side_pocket_width or pt.side_pocket_width
-        self.side_pocket_angle = side_pocket_angle or pt.side_pocket_angle
-        self.side_pocket_depth = side_pocket_depth or pt.side_pocket_depth
-        self.side_pocket_radius = side_pocket_radius or pt.side_pocket_radius
-        self.side_jaw_radius = side_jaw_radius or pt.side_jaw_radius
-        self.height = table_height or pt.table_height # for visualization
-        self.lights_height = lights_height or pt.lights_height # for visualization
+        self.w = table_width or c.table_width
+        self.l = table_length or c.table_length
+        self.cushion_width = cushion_width or c.cushion_width
+        self.cushion_height = cushion_height or c.cushion_height
+        self.corner_pocket_width = corner_pocket_width or c.corner_pocket_width
+        self.corner_pocket_angle = corner_pocket_angle or c.corner_pocket_angle
+        self.corner_pocket_depth = corner_pocket_depth or c.corner_pocket_depth
+        self.corner_pocket_radius = corner_pocket_radius or c.corner_pocket_radius
+        self.corner_jaw_radius = corner_jaw_radius or c.corner_jaw_radius
+        self.side_pocket_width = side_pocket_width or c.side_pocket_width
+        self.side_pocket_angle = side_pocket_angle or c.side_pocket_angle
+        self.side_pocket_depth = side_pocket_depth or c.side_pocket_depth
+        self.side_pocket_radius = side_pocket_radius or c.side_pocket_radius
+        self.side_jaw_radius = side_jaw_radius or c.side_jaw_radius
+        self.height = table_height or c.table_height # for visualization
+        self.lights_height = lights_height or c.lights_height # for visualization
 
         self.center = (self.w/2, self.l/2)
 

--- a/pooltool/objects/table.py
+++ b/pooltool/objects/table.py
@@ -191,22 +191,22 @@ class PocketTable(Object, TableRender):
                  side_pocket_width=None, side_pocket_angle=None, side_pocket_depth=None, side_pocket_radius=None,
                  side_jaw_radius=None, table_height=None, lights_height=None, has_model=False, model_name='none'):
 
-        self.w = table_width or pooltool.table_width
-        self.l = table_length or pooltool.table_length
-        self.cushion_width = cushion_width or pooltool.cushion_width
-        self.cushion_height = cushion_height or pooltool.cushion_height
-        self.corner_pocket_width = corner_pocket_width or pooltool.corner_pocket_width
-        self.corner_pocket_angle = corner_pocket_angle or pooltool.corner_pocket_angle
-        self.corner_pocket_depth = corner_pocket_depth or pooltool.corner_pocket_depth
-        self.corner_pocket_radius = corner_pocket_radius or pooltool.corner_pocket_radius
-        self.corner_jaw_radius = corner_jaw_radius or pooltool.corner_jaw_radius
-        self.side_pocket_width = side_pocket_width or pooltool.side_pocket_width
-        self.side_pocket_angle = side_pocket_angle or pooltool.side_pocket_angle
-        self.side_pocket_depth = side_pocket_depth or pooltool.side_pocket_depth
-        self.side_pocket_radius = side_pocket_radius or pooltool.side_pocket_radius
-        self.side_jaw_radius = side_jaw_radius or pooltool.side_jaw_radius
-        self.height = table_height or pooltool.table_height # for visualization
-        self.lights_height = lights_height or pooltool.lights_height # for visualization
+        self.w = table_width or pt.table_width
+        self.l = table_length or pt.table_length
+        self.cushion_width = cushion_width or pt.cushion_width
+        self.cushion_height = cushion_height or pt.cushion_height
+        self.corner_pocket_width = corner_pocket_width or pt.corner_pocket_width
+        self.corner_pocket_angle = corner_pocket_angle or pt.corner_pocket_angle
+        self.corner_pocket_depth = corner_pocket_depth or pt.corner_pocket_depth
+        self.corner_pocket_radius = corner_pocket_radius or pt.corner_pocket_radius
+        self.corner_jaw_radius = corner_jaw_radius or pt.corner_jaw_radius
+        self.side_pocket_width = side_pocket_width or pt.side_pocket_width
+        self.side_pocket_angle = side_pocket_angle or pt.side_pocket_angle
+        self.side_pocket_depth = side_pocket_depth or pt.side_pocket_depth
+        self.side_pocket_radius = side_pocket_radius or pt.side_pocket_radius
+        self.side_jaw_radius = side_jaw_radius or pt.side_jaw_radius
+        self.height = table_height or pt.table_height # for visualization
+        self.lights_height = lights_height or pt.lights_height # for visualization
 
         self.center = (self.w/2, self.l/2)
 

--- a/pooltool/physics.py
+++ b/pooltool/physics.py
@@ -31,8 +31,8 @@ All units are SI (https://en.wikipedia.org/wiki/International_System_of_Units)
     The acceleration due to gravity felt by a ball.
 """
 
-import pooltool as pt
 import pooltool.utils as utils
+import pooltool.constants as const
 
 import numpy as np
 
@@ -169,14 +169,14 @@ def get_ball_ball_collision_time(rvw1, rvw2, s1, s2, mu1, mu2, m1, m2, g1, g2, R
     c1x, c1y = rvw1[0, 0], rvw1[0, 1]
     c2x, c2y = rvw2[0, 0], rvw2[0, 1]
 
-    if s1 in pt.nontranslating:
+    if s1 in const.nontranslating:
         a1x, a1y, b1x, b1y = 0, 0, 0, 0
     else:
         phi1 = utils.angle(rvw1[1])
         v1 = np.linalg.norm(rvw1[1])
 
         u1 = (np.array([1,0,0])
-              if s1 == pt.rolling
+              if s1 == const.rolling
               else utils.coordinate_rotation(utils.unit_vector(get_rel_velocity(rvw1, R)), -phi1))
 
         a1x = -1/2*mu1*g1*(u1[0]*np.cos(phi1) - u1[1]*np.sin(phi1))
@@ -184,14 +184,14 @@ def get_ball_ball_collision_time(rvw1, rvw2, s1, s2, mu1, mu2, m1, m2, g1, g2, R
         b1x = v1*np.cos(phi1)
         b1y = v1*np.sin(phi1)
 
-    if s2 in pt.nontranslating:
+    if s2 in const.nontranslating:
         a2x, a2y, b2x, b2y = 0, 0, 0, 0
     else:
         phi2 = utils.angle(rvw2[1])
         v2 = np.linalg.norm(rvw2[1])
 
         u2 = (np.array([1,0,0])
-              if s2 == pt.rolling
+              if s2 == const.rolling
               else utils.coordinate_rotation(utils.unit_vector(get_rel_velocity(rvw2, R)), -phi2))
 
         a2x = -1/2*mu2*g2*(u2[0]*np.cos(phi2) - u2[1]*np.sin(phi2))
@@ -212,8 +212,8 @@ def get_ball_ball_collision_time(rvw1, rvw2, s1, s2, mu1, mu2, m1, m2, g1, g2, R
     roots = np.roots([a,b,c,d,e])
 
     roots = roots[
-        (abs(roots.imag) <= pt.tol) & \
-        (roots.real > pt.tol)
+        (abs(roots.imag) <= const.tol) & \
+        (roots.real > const.tol)
     ].real
 
     return roots.min() if len(roots) else np.inf
@@ -221,14 +221,14 @@ def get_ball_ball_collision_time(rvw1, rvw2, s1, s2, mu1, mu2, m1, m2, g1, g2, R
 
 def get_ball_linear_cushion_collision_time(rvw, s, lx, ly, l0, p1, p2, mu, m, g, R):
     """Get the time until collision between ball and linear cushion segment"""
-    if s in pt.nontranslating:
+    if s in const.nontranslating:
         return np.inf
 
     phi = utils.angle(rvw[1])
     v = np.linalg.norm(rvw[1])
 
     u = (np.array([1,0,0]
-         if s == pt.rolling
+         if s == const.rolling
          else utils.coordinate_rotation(utils.unit_vector(get_rel_velocity(rvw, R)), -phi)))
 
     ax = -1/2*mu*g*(u[0]*np.cos(phi) - u[1]*np.sin(phi))
@@ -244,8 +244,8 @@ def get_ball_linear_cushion_collision_time(rvw, s, lx, ly, l0, p1, p2, mu, m, g,
     roots = np.append(np.roots([A,B,C1]), np.roots([A,B,C2]))
 
     roots = roots[
-        (abs(roots.imag) <= pt.tol) & \
-        (roots.real > pt.tol)
+        (abs(roots.imag) <= const.tol) & \
+        (roots.real > const.tol)
     ].real
 
     # All roots beyond this point are real and positive
@@ -274,14 +274,14 @@ def get_ball_circular_cushion_collision_time(rvw, s, a, b, r, mu, m, g, R):
         The rolling or sliding coefficient of friction. Should match the value of s
     """
 
-    if s in pt.nontranslating:
+    if s in const.nontranslating:
         return np.inf
 
     phi = utils.angle(rvw[1])
     v = np.linalg.norm(rvw[1])
 
     u = (np.array([1,0,0]
-         if s == pt.rolling
+         if s == const.rolling
          else utils.coordinate_rotation(utils.unit_vector(get_rel_velocity(rvw, R)), -phi)))
 
     ax = -1/2*mu*g*(u[0]*np.cos(phi) - u[1]*np.sin(phi))
@@ -298,8 +298,8 @@ def get_ball_circular_cushion_collision_time(rvw, s, a, b, r, mu, m, g, R):
     roots = np.roots([A,B,C,D,E])
 
     roots = roots[
-        (abs(roots.imag) <= pt.tol) & \
-        (roots.real > pt.tol)
+        (abs(roots.imag) <= const.tol) & \
+        (roots.real > const.tol)
     ].real
 
     return roots.min() if len(roots) else np.inf
@@ -320,14 +320,14 @@ def get_ball_pocket_collision_time(rvw, s, a, b, r, mu, m, g, R):
         The rolling or sliding coefficient of friction. Should match the value of s
     """
 
-    if s in pt.nontranslating:
+    if s in const.nontranslating:
         return np.inf
 
     phi = utils.angle(rvw[1])
     v = np.linalg.norm(rvw[1])
 
     u = (np.array([1,0,0]
-         if s == pt.rolling
+         if s == const.rolling
          else utils.coordinate_rotation(utils.unit_vector(get_rel_velocity(rvw, R)), -phi)))
 
     ax = -1/2*mu*g*(u[0]*np.cos(phi) - u[1]*np.sin(phi))
@@ -344,8 +344,8 @@ def get_ball_pocket_collision_time(rvw, s, a, b, r, mu, m, g, R):
     roots = np.roots([A,B,C,D,E])
 
     roots = roots[
-        (abs(roots.imag) <= pt.tol) & \
-        (roots.real > pt.tol)
+        (abs(roots.imag) <= const.tol) & \
+        (roots.real > const.tol)
     ].real
 
     return roots.min() if len(roots) else np.inf
@@ -371,48 +371,48 @@ def get_ball_energy(rvw, R, m):
 
 
 def evolve_ball_motion(state, rvw, R, m, u_s, u_sp, u_r, g, t):
-    if state == pt.stationary or state == pt.pocketed:
+    if state == const.stationary or state == const.pocketed:
         return rvw, state
 
-    if state == pt.sliding:
+    if state == const.sliding:
         dtau_E_slide = get_slide_time(rvw, R, u_s, g)
 
         if t >= dtau_E_slide:
             rvw = evolve_slide_state(rvw, R, m, u_s, u_sp, g, dtau_E_slide)
-            state = pt.rolling
+            state = const.rolling
             t -= dtau_E_slide
         else:
-            return evolve_slide_state(rvw, R, m, u_s, u_sp, g, t), pt.sliding
+            return evolve_slide_state(rvw, R, m, u_s, u_sp, g, t), const.sliding
 
-    if state == pt.rolling:
+    if state == const.rolling:
         dtau_E_roll = get_roll_time(rvw, u_r, g)
 
         if t >= dtau_E_roll:
             rvw = evolve_roll_state(rvw, R, u_r, u_sp, g, dtau_E_roll)
-            state = pt.spinning
+            state = const.spinning
             t -= dtau_E_roll
         else:
-            return evolve_roll_state(rvw, R, u_r, u_sp, g, t), pt.rolling
+            return evolve_roll_state(rvw, R, u_r, u_sp, g, t), const.rolling
 
-    if state == pt.spinning:
+    if state == const.spinning:
         dtau_E_spin = get_spin_time(rvw, R, u_sp, g)
 
         if t >= dtau_E_spin:
-            return evolve_perpendicular_spin_state(rvw, R, u_sp, g, dtau_E_spin), pt.stationary
+            return evolve_perpendicular_spin_state(rvw, R, u_sp, g, dtau_E_spin), const.stationary
         else:
-            return evolve_perpendicular_spin_state(rvw, R, u_sp, g, t), pt.spinning
+            return evolve_perpendicular_spin_state(rvw, R, u_sp, g, t), const.spinning
 
 
 def evolve_state_motion(state, rvw, R, m, u_s, u_sp, u_r, g, t):
     """Variant of evolve_ball_motion that does not respect motion transition events"""
-    if state == pt.stationary or state == pt.pocketed:
+    if state == const.stationary or state == const.pocketed:
         return rvw, state
-    elif state == pt.sliding:
-        return evolve_slide_state(rvw, R, m, u_s, u_sp, g, t), pt.sliding
-    elif state == pt.rolling:
-        return evolve_roll_state(rvw, R, u_r, u_sp, g, t), pt.rolling
-    elif state == pt.spinning:
-        return evolve_perpendicular_spin_state(rvw, R, u_sp, g, t), pt.spinning
+    elif state == const.sliding:
+        return evolve_slide_state(rvw, R, m, u_s, u_sp, g, t), const.sliding
+    elif state == const.rolling:
+        return evolve_roll_state(rvw, R, u_r, u_sp, g, t), const.rolling
+    elif state == const.spinning:
+        return evolve_perpendicular_spin_state(rvw, R, u_sp, g, t), const.spinning
 
 
 def evolve_slide_state(rvw, R, m, u_s, u_sp, g, t):
@@ -472,7 +472,7 @@ def evolve_perpendicular_spin_component(wz, R, u_sp, g, t):
     if t == 0:
         return wz
 
-    if abs(wz) < pt.tol:
+    if abs(wz) < const.tol:
         return wz
 
     alpha = 5*u_sp*g/(2*R)
@@ -548,8 +548,8 @@ def cue_strike(m, M, R, V0, phi, theta, a, b):
 
     """
 
-    a *= R*pt.english_fraction
-    b *= R*pt.english_fraction
+    a *= R*const.english_fraction
+    b *= R*const.english_fraction
 
     phi *= np.pi/180
     theta *= np.pi/180

--- a/pooltool/physics.py
+++ b/pooltool/physics.py
@@ -31,7 +31,7 @@ All units are SI (https://en.wikipedia.org/wiki/International_System_of_Units)
     The acceleration due to gravity felt by a ball.
 """
 
-import pooltool
+import pooltool as pt
 import pooltool.utils as utils
 
 import numpy as np
@@ -169,14 +169,14 @@ def get_ball_ball_collision_time(rvw1, rvw2, s1, s2, mu1, mu2, m1, m2, g1, g2, R
     c1x, c1y = rvw1[0, 0], rvw1[0, 1]
     c2x, c2y = rvw2[0, 0], rvw2[0, 1]
 
-    if s1 in pooltool.nontranslating:
+    if s1 in pt.nontranslating:
         a1x, a1y, b1x, b1y = 0, 0, 0, 0
     else:
         phi1 = utils.angle(rvw1[1])
         v1 = np.linalg.norm(rvw1[1])
 
         u1 = (np.array([1,0,0])
-              if s1 == pooltool.rolling
+              if s1 == pt.rolling
               else utils.coordinate_rotation(utils.unit_vector(get_rel_velocity(rvw1, R)), -phi1))
 
         a1x = -1/2*mu1*g1*(u1[0]*np.cos(phi1) - u1[1]*np.sin(phi1))
@@ -184,14 +184,14 @@ def get_ball_ball_collision_time(rvw1, rvw2, s1, s2, mu1, mu2, m1, m2, g1, g2, R
         b1x = v1*np.cos(phi1)
         b1y = v1*np.sin(phi1)
 
-    if s2 in pooltool.nontranslating:
+    if s2 in pt.nontranslating:
         a2x, a2y, b2x, b2y = 0, 0, 0, 0
     else:
         phi2 = utils.angle(rvw2[1])
         v2 = np.linalg.norm(rvw2[1])
 
         u2 = (np.array([1,0,0])
-              if s2 == pooltool.rolling
+              if s2 == pt.rolling
               else utils.coordinate_rotation(utils.unit_vector(get_rel_velocity(rvw2, R)), -phi2))
 
         a2x = -1/2*mu2*g2*(u2[0]*np.cos(phi2) - u2[1]*np.sin(phi2))
@@ -212,8 +212,8 @@ def get_ball_ball_collision_time(rvw1, rvw2, s1, s2, mu1, mu2, m1, m2, g1, g2, R
     roots = np.roots([a,b,c,d,e])
 
     roots = roots[
-        (abs(roots.imag) <= pooltool.tol) & \
-        (roots.real > pooltool.tol)
+        (abs(roots.imag) <= pt.tol) & \
+        (roots.real > pt.tol)
     ].real
 
     return roots.min() if len(roots) else np.inf
@@ -221,14 +221,14 @@ def get_ball_ball_collision_time(rvw1, rvw2, s1, s2, mu1, mu2, m1, m2, g1, g2, R
 
 def get_ball_linear_cushion_collision_time(rvw, s, lx, ly, l0, p1, p2, mu, m, g, R):
     """Get the time until collision between ball and linear cushion segment"""
-    if s in pooltool.nontranslating:
+    if s in pt.nontranslating:
         return np.inf
 
     phi = utils.angle(rvw[1])
     v = np.linalg.norm(rvw[1])
 
     u = (np.array([1,0,0]
-         if s == pooltool.rolling
+         if s == pt.rolling
          else utils.coordinate_rotation(utils.unit_vector(get_rel_velocity(rvw, R)), -phi)))
 
     ax = -1/2*mu*g*(u[0]*np.cos(phi) - u[1]*np.sin(phi))
@@ -244,8 +244,8 @@ def get_ball_linear_cushion_collision_time(rvw, s, lx, ly, l0, p1, p2, mu, m, g,
     roots = np.append(np.roots([A,B,C1]), np.roots([A,B,C2]))
 
     roots = roots[
-        (abs(roots.imag) <= pooltool.tol) & \
-        (roots.real > pooltool.tol)
+        (abs(roots.imag) <= pt.tol) & \
+        (roots.real > pt.tol)
     ].real
 
     # All roots beyond this point are real and positive
@@ -274,14 +274,14 @@ def get_ball_circular_cushion_collision_time(rvw, s, a, b, r, mu, m, g, R):
         The rolling or sliding coefficient of friction. Should match the value of s
     """
 
-    if s in pooltool.nontranslating:
+    if s in pt.nontranslating:
         return np.inf
 
     phi = utils.angle(rvw[1])
     v = np.linalg.norm(rvw[1])
 
     u = (np.array([1,0,0]
-         if s == pooltool.rolling
+         if s == pt.rolling
          else utils.coordinate_rotation(utils.unit_vector(get_rel_velocity(rvw, R)), -phi)))
 
     ax = -1/2*mu*g*(u[0]*np.cos(phi) - u[1]*np.sin(phi))
@@ -298,8 +298,8 @@ def get_ball_circular_cushion_collision_time(rvw, s, a, b, r, mu, m, g, R):
     roots = np.roots([A,B,C,D,E])
 
     roots = roots[
-        (abs(roots.imag) <= pooltool.tol) & \
-        (roots.real > pooltool.tol)
+        (abs(roots.imag) <= pt.tol) & \
+        (roots.real > pt.tol)
     ].real
 
     return roots.min() if len(roots) else np.inf
@@ -320,14 +320,14 @@ def get_ball_pocket_collision_time(rvw, s, a, b, r, mu, m, g, R):
         The rolling or sliding coefficient of friction. Should match the value of s
     """
 
-    if s in pooltool.nontranslating:
+    if s in pt.nontranslating:
         return np.inf
 
     phi = utils.angle(rvw[1])
     v = np.linalg.norm(rvw[1])
 
     u = (np.array([1,0,0]
-         if s == pooltool.rolling
+         if s == pt.rolling
          else utils.coordinate_rotation(utils.unit_vector(get_rel_velocity(rvw, R)), -phi)))
 
     ax = -1/2*mu*g*(u[0]*np.cos(phi) - u[1]*np.sin(phi))
@@ -344,8 +344,8 @@ def get_ball_pocket_collision_time(rvw, s, a, b, r, mu, m, g, R):
     roots = np.roots([A,B,C,D,E])
 
     roots = roots[
-        (abs(roots.imag) <= pooltool.tol) & \
-        (roots.real > pooltool.tol)
+        (abs(roots.imag) <= pt.tol) & \
+        (roots.real > pt.tol)
     ].real
 
     return roots.min() if len(roots) else np.inf
@@ -371,48 +371,48 @@ def get_ball_energy(rvw, R, m):
 
 
 def evolve_ball_motion(state, rvw, R, m, u_s, u_sp, u_r, g, t):
-    if state == pooltool.stationary or state == pooltool.pocketed:
+    if state == pt.stationary or state == pt.pocketed:
         return rvw, state
 
-    if state == pooltool.sliding:
+    if state == pt.sliding:
         dtau_E_slide = get_slide_time(rvw, R, u_s, g)
 
         if t >= dtau_E_slide:
             rvw = evolve_slide_state(rvw, R, m, u_s, u_sp, g, dtau_E_slide)
-            state = pooltool.rolling
+            state = pt.rolling
             t -= dtau_E_slide
         else:
-            return evolve_slide_state(rvw, R, m, u_s, u_sp, g, t), pooltool.sliding
+            return evolve_slide_state(rvw, R, m, u_s, u_sp, g, t), pt.sliding
 
-    if state == pooltool.rolling:
+    if state == pt.rolling:
         dtau_E_roll = get_roll_time(rvw, u_r, g)
 
         if t >= dtau_E_roll:
             rvw = evolve_roll_state(rvw, R, u_r, u_sp, g, dtau_E_roll)
-            state = pooltool.spinning
+            state = pt.spinning
             t -= dtau_E_roll
         else:
-            return evolve_roll_state(rvw, R, u_r, u_sp, g, t), pooltool.rolling
+            return evolve_roll_state(rvw, R, u_r, u_sp, g, t), pt.rolling
 
-    if state == pooltool.spinning:
+    if state == pt.spinning:
         dtau_E_spin = get_spin_time(rvw, R, u_sp, g)
 
         if t >= dtau_E_spin:
-            return evolve_perpendicular_spin_state(rvw, R, u_sp, g, dtau_E_spin), pooltool.stationary
+            return evolve_perpendicular_spin_state(rvw, R, u_sp, g, dtau_E_spin), pt.stationary
         else:
-            return evolve_perpendicular_spin_state(rvw, R, u_sp, g, t), pooltool.spinning
+            return evolve_perpendicular_spin_state(rvw, R, u_sp, g, t), pt.spinning
 
 
 def evolve_state_motion(state, rvw, R, m, u_s, u_sp, u_r, g, t):
     """Variant of evolve_ball_motion that does not respect motion transition events"""
-    if state == pooltool.stationary or state == pooltool.pocketed:
+    if state == pt.stationary or state == pt.pocketed:
         return rvw, state
-    elif state == pooltool.sliding:
-        return evolve_slide_state(rvw, R, m, u_s, u_sp, g, t), pooltool.sliding
-    elif state == pooltool.rolling:
-        return evolve_roll_state(rvw, R, u_r, u_sp, g, t), pooltool.rolling
-    elif state == pooltool.spinning:
-        return evolve_perpendicular_spin_state(rvw, R, u_sp, g, t), pooltool.spinning
+    elif state == pt.sliding:
+        return evolve_slide_state(rvw, R, m, u_s, u_sp, g, t), pt.sliding
+    elif state == pt.rolling:
+        return evolve_roll_state(rvw, R, u_r, u_sp, g, t), pt.rolling
+    elif state == pt.spinning:
+        return evolve_perpendicular_spin_state(rvw, R, u_sp, g, t), pt.spinning
 
 
 def evolve_slide_state(rvw, R, m, u_s, u_sp, g, t):
@@ -472,7 +472,7 @@ def evolve_perpendicular_spin_component(wz, R, u_sp, g, t):
     if t == 0:
         return wz
 
-    if abs(wz) < pooltool.tol:
+    if abs(wz) < pt.tol:
         return wz
 
     alpha = 5*u_sp*g/(2*R)
@@ -548,8 +548,8 @@ def cue_strike(m, M, R, V0, phi, theta, a, b):
 
     """
 
-    a *= R*pooltool.english_fraction
-    b *= R*pooltool.english_fraction
+    a *= R*pt.english_fraction
+    b *= R*pt.english_fraction
 
     phi *= np.pi/180
     theta *= np.pi/180

--- a/pooltool/system.py
+++ b/pooltool/system.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-import pooltool
+import pooltool as pt
 import pooltool.physics as physics
 
 from pooltool.events import *
@@ -202,7 +202,7 @@ class SystemHistory(Events):
                     t=remainder,
                 )
 
-                cts_history.add(rvw, s, next_event.time - pooltool.tol)
+                cts_history.add(rvw, s, next_event.time - pt.tol)
                 cts_history.add(ball.history.rvw[n+1], ball.history.s[n+1], next_event.time)
 
             # Attach the newly created history to the ball, overwriting the existing history

--- a/pooltool/system.py
+++ b/pooltool/system.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
-import pooltool as pt
 import pooltool.physics as physics
+import pooltool.constants as c
 
 from pooltool.events import *
 from pooltool.objects.ball import BallHistory
@@ -202,7 +202,7 @@ class SystemHistory(Events):
                     t=remainder,
                 )
 
-                cts_history.add(rvw, s, next_event.time - pt.tol)
+                cts_history.add(rvw, s, next_event.time - c.tol)
                 cts_history.add(ball.history.rvw[n+1], ball.history.s[n+1], next_event.time)
 
             # Attach the newly created history to the ball, overwriting the existing history


### PR DESCRIPTION
In anticipation of an API, I redesigned the import hierarchy to expose important classes and functions at the highest level import. Before, creating a ball looked like this:

```python
import pooltool
pooltool.objects.ball.Ball()
```

or like this:

```python
from pooltool.objects.ball import Ball
Ball()
```

Now, it looks like this:

```python
import pooltool as pt
pt.Ball()
```

This flattened object tree is great for the API. Yet within the codebase, I opt to use full path imports to avoid issues with import circularity.

In the future, I can add more by altering `pooltool.__init__` statements and if I want to selectively decide which classes should be flattned, I can do so in any specific module by specifying an `__all__` tag (https://stackoverflow.com/questions/44834/can-someone-explain-all-in-python)

With these changes, the current state of the API looks like this for simulating a pool shot:

```python
#! /usr/bin/env python

import pooltool as pt

interface = pt.ShotViewer()

table = pt.PocketTable()
balls = pt.get_nine_ball_rack(table, ordered=True)
cue = pt.Cue(cueing_ball=balls['cue'])

# Aim at the head ball then strike the cue ball
cue.aim_at_ball(balls['1'])
cue.strike(V0=8)

# Evolve the shot
shot = pt.EvolveShotEventBased(cue=cue, table=table, balls=balls)
shot.simulate(continuize=True)

interface.show(shot)
```