### PR TITLE
Adding auto potting support

### DIFF
--- a/pooltool/objects/ball.py
+++ b/pooltool/objects/ball.py
@@ -481,6 +481,7 @@ class Ball(Object, BallRender):
         elif len(xyz) == 2:
             x, y = xyz
             z = self.R
+        self.center = x, y
 
         self.rvw = np.array([[x, y, z], [0, 0, 0], [0, 0, 0]])
         self.update_next_transition_event()

--- a/pooltool/objects/cue.py
+++ b/pooltool/objects/cue.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+import math
 import numpy as np
 from direct.interval.IntervalGlobal import LerpPosInterval, Sequence
 from panda3d.core import (
@@ -387,6 +388,50 @@ class Cue(Object, CueRender):
             utils.unit_vector_fast(np.array(pos) - self.cueing_ball.rvw[0])
         )
         self.set_state(phi=direction * 180 / np.pi)
+
+    def aim_to_pot(self, ball, pockets):
+        def line_equation(p1, p2):
+            (x1, y1), (x2, y2) = p1, p2
+            m = (y2 - y1) / (x2 - x1)
+            b = y1 - m * x1
+            return m, b
+
+        def calc_aiming_point(m, ball_center, pocket, d):
+            # calculate the angle between x-axis and the line
+            theta = math.atan(m)
+
+            # calculate x and y coordinate of the point
+            x0, y0 = ball_center
+            sign = 1 if pocket.id[0] == 'l' else -1 # If the pocket is on the left, add to x0, else subtract
+            aim_p_x = x0 + sign * d * math.cos(theta)
+            aim_p_y = m * aim_p_x + b
+            return aim_p_x, aim_p_y
+
+        def angle_between_points(p1, p2):
+            (x1, y1), (x2, y2) = p1, p2
+            x_diff, y_diff = x2 - x1, y2 - y1
+            return math.degrees(math.atan2(y_diff, x_diff))
+
+        def angle_between_vectors(v1, v2):
+            angle = np.math.atan2(np.linalg.det([v1, v2]), np.dot(v1, v2))
+            return math.degrees(angle)
+
+        def calc_cut_angle(c, b, p):
+            aim_vector = b[0] - c[0], b[1] - c[1]
+            pocket_vector = p[0] - b[0], p[1] - b[1]
+            return angle_between_vectors(aim_vector, pocket_vector)
+
+        aim_point, min_cut_angle = None, 90
+        for pocket in pockets:
+            m, b = line_equation(ball.center, pocket.potting_point)
+            shadow_ball_point = calc_aiming_point(m, ball.center, pocket, 2 * ball.R)
+            cut_angle = calc_cut_angle(self.cueing_ball.center, shadow_ball_point, pocket.potting_point)
+            if abs(cut_angle) < abs(min_cut_angle): # Prefer a straighter shot
+                min_cut_angle = cut_angle
+                aim_point = shadow_ball_point
+
+        potting_angle = 180 if aim_point is None else angle_between_points(self.cueing_ball.center, aim_point)
+        self.phi = potting_angle
 
     def aim_at_ball(self, ball, cut=None):
         """Set phi to aim directly at a ball

--- a/pooltool/objects/table.py
+++ b/pooltool/objects/table.py
@@ -697,6 +697,8 @@ class Pocket(object):
         self.center = np.array(center)
         self.radius = radius
         self.depth = depth
+        self.potting_point = self.calc_potting_point()
+
 
         self.a, self.b = self.center[:2]
 
@@ -708,6 +710,20 @@ class Pocket(object):
 
     def remove(self, ball_id):
         self.contains.remove(ball_id)
+
+    def calc_potting_point(self):
+        (x, y, _), r = self.center, self.radius
+        if self.id[0] == 'l':
+            x = x + r
+        else:
+            x = x - r
+
+        if self.id[1] == 'b':
+            y = y + r
+        elif self.id[1] == 't':
+            y = y - r
+
+        return x, y
 
 
 table_types = {

--- a/sandbox/simple.py
+++ b/sandbox/simple.py
@@ -1,14 +1,17 @@
 """Two balls, a cue, and a table"""
-
+import numpy as np
 import pooltool as pt
 
 # Create a system
+from pooltool.constants import table_length, table_width, R
+cx, cy = np.random.uniform(0, table_width - 2*R), np.random.uniform(0, table_length - 2*R)
+bx, by = np.random.uniform(0, table_width - 2*R), np.random.uniform(0, table_length - 2*R)
 shot = pt.System(
     table=pt.PocketTable(model_name="7_foot"),
     cue=pt.Cue(),
     balls={
-        "cue": pt.Ball("cue", xyz=[0.5, 1]),
-        "1": pt.Ball("1", xyz=[0.16, 1.4]),
+        "cue": pt.Ball("cue", xyz=[cx, cy]),
+        "1": pt.Ball("1", xyz=[bx, by]),
     },
 )
 
@@ -32,7 +35,8 @@ shot.cue.set_state(
 assert shot.cue.phi == 0
 
 # So let's Aim at the 1-ball, with a 30 degree cut to the left
-shot.cue.aim_at_ball(ball=shot.balls["1"], cut=-30)
+target_ball = shot.balls['1']
+shot.cue.aim_to_pot(target_ball, shot.table.pockets.values())
 
 # Now the direction is set!
 assert shot.cue.phi != 0


### PR DESCRIPTION
Adding auto aim-to-put In this commit:

* An aiming point  coordinates (x,y) for each pocket is defined and set in the Pocket class
* A random 2 ball table layout is generated (simple.py)
* A potting pocket is auto selected by "straightest shot" logic
* The ghost ball coordinates are calculated on the line connecting the target ball and the pocket aiming point
* The cue ball is directed towards the ghost ball