### PR TITLE
Auto potting

### DIFF
--- a/pooltool/objects/ball.py
+++ b/pooltool/objects/ball.py
@@ -481,6 +481,7 @@ class Ball(Object, BallRender):
         elif len(xyz) == 2:
             x, y = xyz
             z = self.R
+        self.center = x, y
 
         self.rvw = np.array([[x, y, z], [0, 0, 0], [0, 0, 0]])
         self.update_next_transition_event()

--- a/pooltool/objects/ball.py
+++ b/pooltool/objects/ball.py
@@ -481,7 +481,6 @@ class Ball(Object, BallRender):
         elif len(xyz) == 2:
             x, y = xyz
             z = self.R
-        self.center = x, y
 
         self.rvw = np.array([[x, y, z], [0, 0, 0], [0, 0, 0]])
         self.update_next_transition_event()
@@ -496,6 +495,10 @@ class Ball(Object, BallRender):
 
         self.rel_model_path = rel_model_path
         BallRender.__init__(self, rel_model_path=self.rel_model_path)
+
+    @property
+    def center(self):
+        return self.rvw[0][:2]
 
     def attach_history(self, history):
         """Sets self.history to an existing BallHistory object"""

--- a/pooltool/objects/cue.py
+++ b/pooltool/objects/cue.py
@@ -397,7 +397,7 @@ class Cue(Object, CueRender):
             b = y1 - m * x1
             return m, b
 
-        def calc_aiming_point(m, ball_center, pocket, d):
+        def calc_aiming_point(m, b, ball_center, pocket, d):
             # calculate the angle between x-axis and the line
             theta = math.atan(m)
 
@@ -426,7 +426,7 @@ class Cue(Object, CueRender):
         aim_point, min_cut_angle = None, 90
         for pocket in pockets:
             m, b = line_equation(ball.center, pocket.potting_point)
-            shadow_ball_point = calc_aiming_point(m, ball.center, pocket, 2 * ball.R)
+            shadow_ball_point = calc_aiming_point(m, b, ball.center, pocket, 2 * ball.R)
             cut_angle = calc_cut_angle(
                 self.cueing_ball.center, shadow_ball_point, pocket.potting_point
             )

--- a/pooltool/objects/cue.py
+++ b/pooltool/objects/cue.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+import math
 import numpy as np
 from direct.interval.IntervalGlobal import LerpPosInterval, Sequence
 from panda3d.core import (
@@ -387,6 +388,50 @@ class Cue(Object, CueRender):
             utils.unit_vector_fast(np.array(pos) - self.cueing_ball.rvw[0])
         )
         self.set_state(phi=direction * 180 / np.pi)
+
+    def aim_to_pot(self, ball, pockets):
+        def line_equation(p1, p2):
+            (x1, y1), (x2, y2) = p1, p2
+            m = (y2 - y1) / (x2 - x1)
+            b = y1 - m * x1
+            return m, b
+
+        def calc_aiming_point(m, ball_center, pocket, d):
+            # calculate the angle between x-axis and the line
+            theta = math.atan(m)
+
+            # calculate x and y coordinate of the point
+            x0, y0 = ball_center
+            sign = 1 if pocket.id[0] == 'l' else -1 # If the pocket is on the left, add to x0, else subtract
+            aim_p_x = x0 + sign * d * math.cos(theta)
+            aim_p_y = m * aim_p_x + b
+            return aim_p_x, aim_p_y
+
+        def angle_between_points(p1, p2):
+            (x1, y1), (x2, y2) = p1, p2
+            x_diff, y_diff = x2 - x1, y2 - y1
+            return math.degrees(math.atan2(y_diff, x_diff))
+
+        def angle_between_vectors(v1, v2):
+            angle = np.math.atan2(np.linalg.det([v1, v2]), np.dot(v1, v2))
+            return math.degrees(angle)
+
+        def calc_cut_angle(c, b, p):
+            aim_vector = b[0] - c[0], b[1] - c[1]
+            pocket_vector = p[0] - b[0], p[1] - b[1]
+            return angle_between_vectors(aim_vector, pocket_vector)
+
+        aim_point, min_cut_angle = None, 90
+        for pocket in pockets:
+            m, b = line_equation(ball.center, pocket.potting_point)
+            shadow_ball_point = calc_aiming_point(m, ball.center, pocket, 2 * ball.R)
+            cut_angle = calc_cut_angle(self.cueing_ball.center, shadow_ball_point, pocket.potting_point)
+            if abs(cut_angle) < abs(min_cut_angle): # Prefer a straighter shot
+                min_cut_angle = cut_angle
+                aim_point = shadow_ball_point
+
+        potting_angle = 180 if aim_point is None else angle_between_points(self.cueing_ball.center, aim_point)
+        self.phi = potting_angle
 
     def aim_at_ball(self, ball, cut=None):
         """Set phi to aim directly at a ball

--- a/pooltool/objects/cue.py
+++ b/pooltool/objects/cue.py
@@ -389,9 +389,17 @@ class Cue(Object, CueRender):
         )
         self.set_state(phi=direction * 180 / np.pi)
 
-    def aim_to_pot(self, ball, pockets, config=PottingConfig.default()):
-        """Set phi to pot a given ball into an unchosen pocket"""
-        self.set_state(phi=config.method(self, ball, pockets))
+    def aim_for_pocket(self, ball, pocket, config=PottingConfig.default()):
+        """Set phi to pot a given ball into a given pocket"""
+        self.set_state(phi=config.calculate_angle(self, ball, pocket))
+
+    def aim_for_best_pocket(self, ball, pockets, config=PottingConfig.default()):
+        """Set phi to pot a given ball into the best/easiest pocket"""
+        self.aim_for_pocket(
+            ball=ball,
+            pocket=config.choose_pocket(self, ball, pockets),
+            config=config,
+        )
 
     def aim_at_ball(self, ball, cut=None):
         """Set phi to aim directly at a ball

--- a/pooltool/objects/cue.py
+++ b/pooltool/objects/cue.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 import math
+
 import numpy as np
 from direct.interval.IntervalGlobal import LerpPosInterval, Sequence
 from panda3d.core import (
@@ -402,7 +403,8 @@ class Cue(Object, CueRender):
 
             # calculate x and y coordinate of the point
             x0, y0 = ball_center
-            sign = 1 if pocket.id[0] == 'l' else -1 # If the pocket is on the left, add to x0, else subtract
+            # If the pocket is on the left, add to x0, else subtract
+            sign = 1 if pocket.id[0] == "l" else -1
             aim_p_x = x0 + sign * d * math.cos(theta)
             aim_p_y = m * aim_p_x + b
             return aim_p_x, aim_p_y
@@ -425,12 +427,18 @@ class Cue(Object, CueRender):
         for pocket in pockets:
             m, b = line_equation(ball.center, pocket.potting_point)
             shadow_ball_point = calc_aiming_point(m, ball.center, pocket, 2 * ball.R)
-            cut_angle = calc_cut_angle(self.cueing_ball.center, shadow_ball_point, pocket.potting_point)
-            if abs(cut_angle) < abs(min_cut_angle): # Prefer a straighter shot
+            cut_angle = calc_cut_angle(
+                self.cueing_ball.center, shadow_ball_point, pocket.potting_point
+            )
+            if abs(cut_angle) < abs(min_cut_angle):  # Prefer a straighter shot
                 min_cut_angle = cut_angle
                 aim_point = shadow_ball_point
 
-        potting_angle = 180 if aim_point is None else angle_between_points(self.cueing_ball.center, aim_point)
+        potting_angle = (
+            180
+            if aim_point is None
+            else angle_between_points(self.cueing_ball.center, aim_point)
+        )
         self.phi = potting_angle
 
     def aim_at_ball(self, ball, cut=None):

--- a/pooltool/objects/table.py
+++ b/pooltool/objects/table.py
@@ -699,7 +699,6 @@ class Pocket(object):
         self.depth = depth
         self.potting_point = self.calc_potting_point()
 
-
         self.a, self.b = self.center[:2]
 
         # hold ball ids of balls the pocket contains
@@ -713,14 +712,14 @@ class Pocket(object):
 
     def calc_potting_point(self):
         (x, y, _), r = self.center, self.radius
-        if self.id[0] == 'l':
+        if self.id[0] == "l":
             x = x + r
         else:
             x = x - r
 
-        if self.id[1] == 'b':
+        if self.id[1] == "b":
             y = y + r
-        elif self.id[1] == 't':
+        elif self.id[1] == "t":
             y = y - r
 
         return x, y

--- a/pooltool/objects/table.py
+++ b/pooltool/objects/table.py
@@ -697,6 +697,8 @@ class Pocket(object):
         self.center = np.array(center)
         self.radius = radius
         self.depth = depth
+        self.potting_point = self.calc_potting_point()
+
 
         self.a, self.b = self.center[:2]
 
@@ -708,6 +710,20 @@ class Pocket(object):
 
     def remove(self, ball_id):
         self.contains.remove(ball_id)
+
+    def calc_potting_point(self):
+        (x, y, _), r = self.center, self.radius
+        if self.id[0] == 'l':
+            x = x + r
+        else:
+            x = x - r
+
+        if self.id[1] == 'b':
+            y = y + r
+        elif self.id[1] == 't':
+            y = y - r
+
+        return x, y
 
 
 table_types = {

--- a/pooltool/objects/table.py
+++ b/pooltool/objects/table.py
@@ -711,6 +711,10 @@ class Pocket(object):
         self.contains.remove(ball_id)
 
     def calc_potting_point(self):
+        """ Determines the coordinates of a point ahead of the pocket where, if a traveling ball were to pass through
+        it, would result in the ball being sunk. The point would be a radius to left/right, and a radius up/down,
+        depending on the pocket. These values were determined empirically by trail and error.
+        """
         (x, y, _), r = self.center, self.radius
         if self.id[0] == "l":
             x = x + r

--- a/pooltool/objects/table.py
+++ b/pooltool/objects/table.py
@@ -722,7 +722,7 @@ class Pocket(object):
         elif self.id[1] == "t":
             y = y - r
 
-        return x, y
+        return np.array([x, y])
 
 
 table_types = {

--- a/pooltool/potting/__init__.py
+++ b/pooltool/potting/__init__.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from pooltool.potting.simple import calc_potting_angle as calc_potting_angle_simple
+
+
+@dataclass
+class PottingConfig:
+    method: Callable
+
+    @staticmethod
+    def default() -> PottingConfig:
+        return PottingConfig(
+            method=calc_potting_angle_simple,
+        )

--- a/pooltool/potting/__init__.py
+++ b/pooltool/potting/__init__.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable
 
-from pooltool.potting.simple import calc_potting_angle as calc_potting_angle_simple
+from pooltool.potting.simple import calc_potting_angle, pick_best_pot
 
 
 @dataclass
 class PottingConfig:
-    method: Callable
+    calculate_angle: Callable
+    choose_pocket: Callable
 
     @staticmethod
     def default() -> PottingConfig:
         return PottingConfig(
-            method=calc_potting_angle_simple,
+            calculate_angle=calc_potting_angle,
+            choose_pocket=pick_best_pot,
         )

--- a/pooltool/potting/simple.py
+++ b/pooltool/potting/simple.py
@@ -1,0 +1,67 @@
+"""A simple aiming procedure
+
+The concept of this aiming procedure is to determine the cueing angle phi such that the
+cue ball contacts the object ball on the aim line. Cut- and spin-induced throw is
+ignored. Bank shots are not supported. Interfering balls are not detected.
+"""
+
+import math
+
+import numpy as np
+
+
+def line_equation(p1, p2):
+    (x1, y1), (x2, y2) = p1, p2
+    m = (y2 - y1) / (x2 - x1)
+    b = y1 - m * x1
+    return m, b
+
+
+def calc_aiming_point(m, b, ball_center, pocket, d):
+    # calculate the angle between x-axis and the line
+    theta = math.atan(m)
+
+    # calculate x and y coordinate of the point
+    x0, y0 = ball_center
+    # If the pocket is on the left, add to x0, else subtract
+    sign = 1 if pocket.id[0] == "l" else -1
+    aim_p_x = x0 + sign * d * math.cos(theta)
+    aim_p_y = m * aim_p_x + b
+    return aim_p_x, aim_p_y
+
+
+def angle_between_points(p1, p2):
+    (x1, y1), (x2, y2) = p1, p2
+    x_diff, y_diff = x2 - x1, y2 - y1
+    return math.degrees(math.atan2(y_diff, x_diff))
+
+
+def angle_between_vectors(v1, v2):
+    angle = np.math.atan2(np.linalg.det([v1, v2]), np.dot(v1, v2))
+    return math.degrees(angle)
+
+
+def calc_cut_angle(c, b, p):
+    aim_vector = b[0] - c[0], b[1] - c[1]
+    pocket_vector = p[0] - b[0], p[1] - b[1]
+    return angle_between_vectors(aim_vector, pocket_vector)
+
+
+def calc_potting_angle(cue, ball, pockets):
+    """Return the cue phi angle required to pot the ball"""
+    aim_point, min_cut_angle = None, 90
+    for pocket in pockets:
+        m, b = line_equation(ball.center, pocket.potting_point)
+        shadow_ball_point = calc_aiming_point(m, b, ball.center, pocket, 2 * ball.R)
+        cut_angle = calc_cut_angle(
+            cue.cueing_ball.center, shadow_ball_point, pocket.potting_point
+        )
+        if abs(cut_angle) < abs(min_cut_angle):  # Prefer a straighter shot
+            min_cut_angle = cut_angle
+            aim_point = shadow_ball_point
+
+    return (
+        180
+        if aim_point is None
+        else angle_between_points(cue.cueing_ball.center, aim_point)
+    )

--- a/pooltool/potting/simple.py
+++ b/pooltool/potting/simple.py
@@ -17,7 +17,9 @@ def line_equation(p1, p2):
     return m, b
 
 
-def calc_aiming_point(m, b, ball, pocket):
+def calc_aiming_point(ball, pocket):
+    m, b = line_equation(ball.center, pocket.potting_point)
+
     # calculate the angle between x-axis and the line
     theta = math.atan(m)
 
@@ -50,8 +52,7 @@ def calc_cut_angle(c, b, p):
 
 def calc_shadow_ball_center(ball, pocket):
     """Return coordinates of shadow ball for potting into specific pocket"""
-    m, b = line_equation(ball.center, pocket.potting_point)
-    return calc_aiming_point(m, b, ball, pocket)
+    return calc_aiming_point(ball, pocket)
 
 
 def calc_potting_angle(cue, ball, pocket):

--- a/pooltool/potting/simple.py
+++ b/pooltool/potting/simple.py
@@ -48,7 +48,7 @@ def calc_cut_angle(c, b, p):
     return angle_between_vectors(aim_vector, pocket_vector)
 
 
-def calc_shadow_ball_center(cue, ball, pocket):
+def calc_shadow_ball_center(ball, pocket):
     """Return coordinates of shadow ball for potting into specific pocket"""
     m, b = line_equation(ball.center, pocket.potting_point)
     return calc_aiming_point(m, b, ball, pocket)
@@ -60,7 +60,7 @@ def calc_potting_angle(cue, ball, pocket):
         return 180
 
     return angle_between_points(
-        cue.cueing_ball.center, calc_shadow_ball_center(cue, ball, pocket)
+        cue.cueing_ball.center, calc_shadow_ball_center(ball, pocket)
     )
 
 
@@ -75,7 +75,7 @@ def pick_best_pot(cue, ball, pockets):
     for pocket in pockets:
         cut_angle = calc_cut_angle(
             c=cue.cueing_ball.center,
-            b=calc_shadow_ball_center(cue, ball, pocket),
+            b=calc_shadow_ball_center(ball, pocket),
             p=pocket.potting_point,
         )
         if abs(cut_angle) < abs(min_cut_angle):  # Prefer a straighter shot

--- a/pooltool/potting/simple.py
+++ b/pooltool/potting/simple.py
@@ -17,22 +17,6 @@ def line_equation(p1, p2):
     return m, b
 
 
-def calc_aiming_point(ball, pocket):
-    m, b = line_equation(ball.center, pocket.potting_point)
-
-    # calculate the angle between x-axis and the line
-    theta = math.atan(m)
-
-    # calculate x and y coordinate of the point
-    x0, y0 = ball.center
-    # If the pocket is on the left, add to x0, else subtract
-    d = ball.R * 2
-    sign = 1 if pocket.id[0] == "l" else -1
-    aim_p_x = x0 + sign * d * math.cos(theta)
-    aim_p_y = m * aim_p_x + b
-    return aim_p_x, aim_p_y
-
-
 def angle_between_points(p1, p2):
     (x1, y1), (x2, y2) = p1, p2
     x_diff, y_diff = x2 - x1, y2 - y1
@@ -52,7 +36,19 @@ def calc_cut_angle(c, b, p):
 
 def calc_shadow_ball_center(ball, pocket):
     """Return coordinates of shadow ball for potting into specific pocket"""
-    return calc_aiming_point(ball, pocket)
+    m, b = line_equation(ball.center, pocket.potting_point)
+
+    # calculate the angle between x-axis and the line
+    theta = math.atan(m)
+
+    # calculate x and y coordinate of the point
+    x0, y0 = ball.center
+    # If the pocket is on the left, add to x0, else subtract
+    d = ball.R * 2
+    sign = 1 if pocket.id[0] == "l" else -1
+    aim_p_x = x0 + sign * d * math.cos(theta)
+    aim_p_y = m * aim_p_x + b
+    return aim_p_x, aim_p_y
 
 
 def calc_potting_angle(cue, ball, pocket):

--- a/pooltool/potting/simple.py
+++ b/pooltool/potting/simple.py
@@ -17,13 +17,14 @@ def line_equation(p1, p2):
     return m, b
 
 
-def calc_aiming_point(m, b, ball_center, pocket, d):
+def calc_aiming_point(m, b, ball, pocket):
     # calculate the angle between x-axis and the line
     theta = math.atan(m)
 
     # calculate x and y coordinate of the point
-    x0, y0 = ball_center
+    x0, y0 = ball.center
     # If the pocket is on the left, add to x0, else subtract
+    d = ball.R * 2
     sign = 1 if pocket.id[0] == "l" else -1
     aim_p_x = x0 + sign * d * math.cos(theta)
     aim_p_y = m * aim_p_x + b

--- a/pooltool/potting/simple.py
+++ b/pooltool/potting/simple.py
@@ -51,7 +51,7 @@ def calc_cut_angle(c, b, p):
 def calc_shadow_ball_center(cue, ball, pocket):
     """Return coordinates of shadow ball for potting into specific pocket"""
     m, b = line_equation(ball.center, pocket.potting_point)
-    return calc_aiming_point(m, b, ball.center, pocket, 2 * ball.R)
+    return calc_aiming_point(m, b, ball, pocket)
 
 
 def calc_potting_angle(cue, ball, pocket):

--- a/pooltool/potting/simple.py
+++ b/pooltool/potting/simple.py
@@ -9,12 +9,7 @@ import math
 
 import numpy as np
 
-
-def line_equation(p1, p2):
-    (x1, y1), (x2, y2) = p1, p2
-    m = (y2 - y1) / (x2 - x1)
-    b = y1 - m * x1
-    return m, b
+from pooltool.utils import unit_vector
 
 
 def angle_between_points(p1, p2):
@@ -36,19 +31,15 @@ def calc_cut_angle(c, b, p):
 
 def calc_shadow_ball_center(ball, pocket):
     """Return coordinates of shadow ball for potting into specific pocket"""
-    m, b = line_equation(ball.center, pocket.potting_point)
 
-    # calculate the angle between x-axis and the line
-    theta = math.atan(m)
+    # Calculate the unit vector drawn from the object ball to the pocket
+    ball_to_pocket_vector = unit_vector(pocket.potting_point - ball.center)
 
-    # calculate x and y coordinate of the point
-    x0, y0 = ball.center
-    # If the pocket is on the left, add to x0, else subtract
-    d = ball.R * 2
-    sign = 1 if pocket.id[0] == "l" else -1
-    aim_p_x = x0 + sign * d * math.cos(theta)
-    aim_p_y = m * aim_p_x + b
-    return aim_p_x, aim_p_y
+    # The shadow ball center is two ball radii away from the object ball center
+    magnitude = ball.R * 2
+
+    # In the direction opposite the ball to pocket vector
+    return ball.center - ball_to_pocket_vector * magnitude
 
 
 def calc_potting_angle(cue, ball, pocket):

--- a/pooltool/potting/simple.py
+++ b/pooltool/potting/simple.py
@@ -81,7 +81,4 @@ def pick_best_pot(cue, ball, pockets):
             min_cut_angle = cut_angle
             best_pocket = pocket
 
-    if best_pocket is None:
-        raise NotImplementedError("Uh oh.")
-
     return best_pocket

--- a/sandbox/simple.py
+++ b/sandbox/simple.py
@@ -1,11 +1,14 @@
 """Two balls, a cue, and a table"""
 import numpy as np
-import pooltool as pt
 
-# Create a system
-from pooltool.constants import table_length, table_width, R
-cx, cy = np.random.uniform(0, table_width - 2*R), np.random.uniform(0, table_length - 2*R)
-bx, by = np.random.uniform(0, table_width - 2*R), np.random.uniform(0, table_length - 2*R)
+import pooltool as pt
+from pooltool.constants import R, table_length, table_width
+
+# Create a 2-ball system (randomly placed balls)
+cx = np.random.uniform(0, table_width - 2 * R)
+cy = np.random.uniform(0, table_length - 2 * R)
+bx = np.random.uniform(0, table_width - 2 * R)
+by = np.random.uniform(0, table_length - 2 * R)
 shot = pt.System(
     table=pt.PocketTable(model_name="7_foot"),
     cue=pt.Cue(),
@@ -35,7 +38,7 @@ shot.cue.set_state(
 assert shot.cue.phi == 0
 
 # So let's Aim at the 1-ball, with a 30 degree cut to the left
-target_ball = shot.balls['1']
+target_ball = shot.balls["1"]
 shot.cue.aim_to_pot(target_ball, shot.table.pockets.values())
 
 # Now the direction is set!
@@ -61,6 +64,3 @@ print(shot.events)
 # We can visualize the shot like so (press r to replay):
 interface = pt.ShotViewer()
 interface.show(shot)
-
-# Oh no! it's a scratch. Try avoiding the scratch by modifying the cue ball's spin in
-# the code above

--- a/sandbox/simple.py
+++ b/sandbox/simple.py
@@ -1,14 +1,17 @@
 """Two balls, a cue, and a table"""
-
+import numpy as np
 import pooltool as pt
 
 # Create a system
+from pooltool.constants import table_length, table_width, R
+cx, cy = np.random.uniform(0, table_width - 2*R), np.random.uniform(0, table_length - 2*R)
+bx, by = np.random.uniform(0, table_width - 2*R), np.random.uniform(0, table_length - 2*R)
 shot = pt.System(
     table=pt.PocketTable(model_name="7_foot"),
     cue=pt.Cue(),
     balls={
-        "cue": pt.Ball("cue", xyz=[0.5, 1]),
-        "1": pt.Ball("1", xyz=[0.16, 1.4]),
+        "cue": pt.Ball("cue", xyz=[cx, cy]),
+        "1": pt.Ball("1", xyz=[bx, by]),
     },
 )
 
@@ -32,7 +35,8 @@ shot.cue.set_state(
 assert shot.cue.phi == 0
 
 # So let's Aim at the 1-ball, with a 30 degree cut to the left
-shot.cue.aim_at_ball(ball=shot.balls["1"], cut=-30)
+target_ball = shot.balls['1']
+shot.cue.aim_to_pot(target_ball, shot.table.pockets.values())
 
 # Now the direction is set!
 assert shot.cue.phi != 0

--- a/sandbox/simple.py
+++ b/sandbox/simple.py
@@ -39,7 +39,7 @@ assert shot.cue.phi == 0
 
 # So let's Aim at the 1-ball, with a 30 degree cut to the left
 target_ball = shot.balls["1"]
-shot.cue.aim_to_pot(target_ball, shot.table.pockets.values())
+shot.cue.aim_for_best_pocket(target_ball, shot.table.pockets.values())
 
 # Now the direction is set!
 assert shot.cue.phi != 0


### PR DESCRIPTION
Adding auto aim-to-put In this commit:

* An aiming point  coordinates (x,y) for each pocket is defined and set in the Pocket class
* A random 2 ball table layout is generated (simple.py)
* A potting pocket is auto selected by "straightest shot" logic
* The ghost ball coordinates are calculated on the line connecting the target ball and the pocket aiming point
* The cue ball is directed towards the ghost ball