### PR TITLE
Read only arrays

### DIFF
--- a/pooltool/ani/environment.py
+++ b/pooltool/ani/environment.py
@@ -257,10 +257,10 @@ class Environment:
         self.lights_loaded = True
 
     def set_table_offset(self, table):
-        self.offset = (table.w / 2, table.l / 2, -table.specs.height)
+        self.offset = (table.w / 2, table.l / 2, -table.height)
         self.table_w = table.w
         self.table_l = table.l
-        self.lights_height = table.specs.lights_height + table.specs.height
+        self.lights_height = table.lights_height + table.height
 
     def load_room(self, path):
         self.room = Global.loader.loadModel(panda_path(path))

--- a/pooltool/ani/modes/shot.py
+++ b/pooltool/ani/modes/shot.py
@@ -174,11 +174,7 @@ class ShotMode(BaseMode):
             for ball_render in visual.balls.values():
                 ball = ball_render._ball
                 if not ball.history.empty:
-                    ball.state.set(
-                        rvw=ball.history[0].rvw,
-                        s=ball.history[0].s,
-                        t=0,
-                    )
+                    ball.state = ball.history[0]
                     ball_render.get_node("pos").setQuat(ball_render.quats[0])
                 ball_render.set_render_state_as_object_state()
                 ball.history = BallHistory()

--- a/pooltool/objects/ball/datatypes.py
+++ b/pooltool/objects/ball/datatypes.py
@@ -94,6 +94,8 @@ class BallState:
     t: float
 
     def __post_init__(self):
+        # FIXME this is safest, but in my preliminary tests, it is not necessary. If
+        # np.copy calls are bogging down shot calculation, this should be looked into
         self.rvw = np.copy(self.rvw)
 
     def __eq__(self, other):

--- a/pooltool/objects/ball/datatypes.py
+++ b/pooltool/objects/ball/datatypes.py
@@ -99,13 +99,6 @@ class BallState:
     def __eq__(self, other):
         return are_dataclasses_equal(self, other)
 
-    def set(self, rvw, s=None, t=None) -> None:
-        self.rvw = rvw
-        if s is not None:
-            self.s = s
-        if t is not None:
-            self.t = t
-
     def copy(self) -> BallState:
         """Create a deep copy"""
         # Twice as fast as copy.deepcopy(self)

--- a/pooltool/objects/cue/datatypes.py
+++ b/pooltool/objects/cue/datatypes.py
@@ -33,7 +33,11 @@ class Cue:
     specs: CueSpecs = field(default_factory=CueSpecs.default)
 
     def copy(self) -> Cue:
-        """Create a deep copy"""
+        """Create a deep-ish copy
+
+        `specs` is shared between self and the copy, but that's ok because it's frozen
+        and has no mutable attributes
+        """
         return replace(self)
 
     def reset_state(self):

--- a/pooltool/objects/cue/test_datatypes.py
+++ b/pooltool/objects/cue/test_datatypes.py
@@ -9,12 +9,13 @@ def test_cue_copy():
     cue = Cue()
     copy = cue.copy()
 
-    # `specs` is frozen
-    with pytest.raises(FrozenInstanceError):
-        cue.specs.brand = "brunswick"
-
     # cue and copy equate
     assert cue == copy
+
+    # The specs are the same object but thats ok because `specs` is frozen
+    assert cue.specs is copy.specs
+    with pytest.raises(FrozenInstanceError):
+        cue.specs.brand = "brunswick"
 
     # modifying cue doesn't affect copy
     cue.phi += 1

--- a/pooltool/objects/table/components.py
+++ b/pooltool/objects/table/components.py
@@ -53,6 +53,10 @@ class LinearCushionSegment:
         # Segment must have constant height
         assert self.p1[2] == self.p2[2]
 
+        # p1 and p2 are read only
+        self.p1.flags["WRITEABLE"] = False
+        self.p2.flags["WRITEABLE"] = False
+
     def __eq__(self, other):
         return are_dataclasses_equal(self, other)
 
@@ -85,11 +89,7 @@ class LinearCushionSegment:
 
     def copy(self):
         """Create a deep copy"""
-        return replace(
-            self,
-            p1=np.copy(self.p1),
-            p2=np.copy(self.p2),
-        )
+        return replace(self)
 
     @staticmethod
     def dummy() -> LinearCushionSegment:

--- a/pooltool/objects/table/components.py
+++ b/pooltool/objects/table/components.py
@@ -88,8 +88,13 @@ class LinearCushionSegment:
         return self.normal
 
     def copy(self):
-        """Create a deep copy"""
-        return replace(self)
+        """Create a deep-ish copy
+
+        LinearCushionSegment is a frozen instance, and its attributes are either (a)
+        immutable, or (b) have read-only flags set. It is sufficient to simply return
+        oneself.
+        """
+        return self
 
     @staticmethod
     def dummy() -> LinearCushionSegment:
@@ -120,6 +125,9 @@ class CircularCushionSegment:
     def __post_init__(self):
         assert len(self.center) == 3
 
+        # center is read only
+        self.center.flags["WRITEABLE"] = False
+
     @property
     def height(self) -> float:
         return self.center[2]
@@ -138,8 +146,13 @@ class CircularCushionSegment:
         return normal
 
     def copy(self) -> CircularCushionSegment:
-        """Create a deepcopy"""
-        return replace(self, center=np.copy(self.center))
+        """Create a deep-ish copy
+
+        CircularCushionSegment is a frozen instance, and its attributes are either (a)
+        immutable, or (b) have read-only flags set. It is sufficient to simply return
+        oneself.
+        """
+        return self
 
     @staticmethod
     def dummy() -> CircularCushionSegment:
@@ -155,11 +168,17 @@ class CushionSegments:
     circular: Dict[str, CircularCushionSegment]
 
     def copy(self) -> CushionSegments:
-        """Create a deepcopy"""
+        """Create a deep-ish copy
+
+        Delegates the deep-ish copying of LinearCushionSegment and
+        CircularCushionSegment elements to their respective copy() methods. Uses
+        dictionary comprehensions to construct equal but different `linear` and
+        `circular` attributes.
+        """
         return replace(
             self,
             linear={k: v.copy() for k, v in self.linear.items()},
-            circular={k: v for k, v in self.circular.items()},
+            circular={k: v.copy() for k, v in self.circular.items()},
         )
 
 
@@ -174,6 +193,9 @@ class Pocket:
     def __post_init__(self):
         assert len(self.center) == 3
         assert self.center[2] == 0
+
+        # center is read only
+        self.center.flags["WRITEABLE"] = False
 
     def __eq__(self, other):
         return are_dataclasses_equal(self, other)
@@ -209,17 +231,21 @@ class Pocket:
 
         return np.array([x, y], dtype=np.float64)
 
-    def add(self, ball_id) -> None:
+    def add(self, ball_id: str) -> None:
         self.contains.add(ball_id)
 
-    def remove(self, ball_id) -> None:
+    def remove(self, ball_id: str) -> None:
         self.contains.remove(ball_id)
 
     def copy(self) -> Pocket:
-        """Create a deepcopy"""
-        return replace(
-            self, center=np.copy(self.center), contains=copy.deepcopy(self.contains)
-        )
+        """Create a deep-ish copy
+
+        Pocket is a frozen instance, and except for `contains`, its attributes are
+        either (a) immutable, or (b) have read-only flags set. Therefore, only a copy of
+        `contains` needs to be made. Since it's members are strs (immutable), a shallow
+        copy suffices.
+        """
+        return replace(self, contains=copy.copy(self.contains))
 
     @staticmethod
     def dummy() -> Pocket:

--- a/pooltool/objects/table/datatypes.py
+++ b/pooltool/objects/table/datatypes.py
@@ -164,7 +164,12 @@ class Table:
         return self.w / 2, self.l / 2
 
     def copy(self) -> Table:
-        """Create a deepcopy"""
+        """Create a deep-ish copy
+
+        Delegates the deep-ish copying of CushionSegments and Pocket to their respective
+        copy() methods. Uses dictionary comprehension to construct equal but different
+        `pockets` attribute.  All other attributes are frozen or immutable.
+        """
         return replace(
             self,
             cushion_segments=self.cushion_segments.copy(),

--- a/pooltool/objects/table/datatypes.py
+++ b/pooltool/objects/table/datatypes.py
@@ -79,27 +79,10 @@ class PocketTableSpecs:
     side_jaw_radius: float = field(default=0.0159 / 2)
 
     # For visualization
-    model_descr: Optional[TableModelDescr] = None
     height: float = field(default=0.708)
     lights_height: float = field(default=1.99)
 
     table_type: TableType = field(init=False, default=TableType.POCKET)
-
-    def __post_init__(self):
-        field_defaults = {
-            fname: field.default
-            for fname, field in self.__dataclass_fields__.items()
-            if field.init
-        }
-
-        if all(
-            getattr(self, fname) == default for fname, default in field_defaults.items()
-        ):
-            # All parameters match the default table, and so the TableModelDescr is used
-            # even if it wasn't explictly requested.
-            object.__setattr__(
-                self, "model_descr", TableModelDescr.pocket_table_default()
-            )
 
     def create_cushion_segments(self) -> CushionSegments:
         return _create_pocket_table_cushion_segments(self)
@@ -121,25 +104,10 @@ class BilliardTableSpecs:
     cushion_height: float = field(default=0.64 * 2 * 0.028575)
 
     # For visualization
-    model_descr: Optional[TableModelDescr] = None
     height: float = field(default=0.708)
     lights_height: float = field(default=1.99)
 
     table_type: TableType = field(init=False, default=TableType.BILLIARD)
-
-    def __post_init__(self):
-        field_defaults = {
-            fname: field.default
-            for fname, field in self.__dataclass_fields__.items()
-            if field.init
-        }
-
-        if all(
-            getattr(self, fname) == default for fname, default in field_defaults.items()
-        ):
-            # All parameters match the default table, and so the TableModelDescr is used
-            # even if it wasn't explictly requested.
-            self.model_descr = TableModelDescr.billiard_table_default()
 
     def create_cushion_segments(self) -> CushionSegments:
         return _create_billiard_table_cushion_segments(self)
@@ -148,13 +116,18 @@ class BilliardTableSpecs:
         return {}
 
 
+@dataclass
 class TableSpecs(Protocol):
     @property
-    def l(self):
+    def table_type(self):
         ...
 
     @property
-    def w(self):
+    def height(self):
+        ...
+
+    @property
+    def lights_height(self):
         ...
 
     def create_cushion_segments(self):
@@ -166,17 +139,25 @@ class TableSpecs(Protocol):
 
 @dataclass
 class Table:
-    specs: TableSpecs
     cushion_segments: CushionSegments
     pockets: Dict[str, Pocket]
+    table_type: TableType
+    model_descr: Optional[TableModelDescr] = field(default=None)
+    height: float = field(default=0.708)
+    lights_height: float = field(default=1.99)
 
     @property
     def w(self) -> float:
-        return self.specs.w
+        """The width of the table"""
+        x2 = self.cushion_segments.linear["15"].p1[0]
+        x1 = self.cushion_segments.linear["3"].p1[0]
+        return x2 - x1
 
     @property
     def l(self) -> float:
-        return self.specs.l
+        y2 = self.cushion_segments.linear["9"].p1[1]
+        y1 = self.cushion_segments.linear["18"].p1[1]
+        return y2 - y1
 
     @property
     def center(self) -> Tuple[float, float]:
@@ -192,10 +173,34 @@ class Table:
 
     @staticmethod
     def from_table_specs(specs: TableSpecs) -> Table:
+        field_defaults = {
+            fname: field.default
+            for fname, field in specs.__dataclass_fields__.items()
+            if field.init
+        }
+
+        if all(
+            getattr(specs, fname) == default
+            for fname, default in field_defaults.items()
+        ):
+            # All parameters match the default table, for which a model exists. So use
+            # the corresponding TableModelDescr
+            if specs.table_type == TableType.BILLIARD:
+                model_descr = TableModelDescr.billiard_table_default()
+            elif specs.table_type == TableType.POCKET:
+                model_descr = TableModelDescr.pocket_table_default()
+            else:
+                raise NotImplementedError()
+        else:
+            model_descr = None
+
         return Table(
-            specs=specs,
             cushion_segments=specs.create_cushion_segments(),
             pockets=specs.create_pockets(),
+            table_type=specs.table_type,
+            height=specs.height,
+            lights_height=specs.lights_height,
+            model_descr=model_descr,
         )
 
     @staticmethod

--- a/pooltool/objects/table/render.py
+++ b/pooltool/objects/table/render.py
@@ -16,8 +16,8 @@ class TableRender(Render):
 
     def init_table(self):
         if (
-            not self._table.specs.model_descr
-            or self._table.specs.model_descr == TableModelDescr.null()
+            not self._table.model_descr
+            or self._table.model_descr == TableModelDescr.null()
             or not ani.settings["graphics"]["table"]
         ):
             model = Global.loader.loadModel(TableModelDescr.null().path)
@@ -25,7 +25,7 @@ class TableRender(Render):
             model.reparentTo(node)
             model.setScale(self._table.w, self._table.l, 1)
         else:
-            node = Global.loader.loadModel(self._table.specs.model_descr.path)
+            node = Global.loader.loadModel(self._table.model_descr.path)
             node.reparentTo(Global.render.find("scene"))
             node.setName("table")
 
@@ -36,7 +36,7 @@ class TableRender(Render):
         if not ani.settings["gameplay"]["cue_collision"]:
             return
 
-        if self._table.specs.table_type not in (TableType.BILLIARD, TableType.POCKET):
+        if self._table.table_type not in (TableType.BILLIARD, TableType.POCKET):
             raise NotImplementedError()
 
         # Make 4 planes
@@ -120,8 +120,8 @@ class TableRender(Render):
         self.init_table()
 
         if (
-            not self._table.specs.model_descr
-            or self._table.specs.model_descr == TableModelDescr.null()
+            not self._table.model_descr
+            or self._table.model_descr == TableModelDescr.null()
             or not ani.settings["graphics"]["table"]
         ):
             # draw cushion_segments as edges

--- a/pooltool/objects/table/test_components.py
+++ b/pooltool/objects/table/test_components.py
@@ -53,20 +53,16 @@ def test_linear_segment_frozen(lin_seg):
     with pytest.raises(FrozenInstanceError):
         lin_seg.p1 = np.array([10, 10, 10])
 
-    # Unfortunately, this is allowed
-    lin_seg.p1[0] = 10
+    # Cannot even modify array elements
+    with pytest.raises(ValueError, match="assignment destination is read-only"):
+        lin_seg.p1[0] = 10
 
 
 def test_linear_segment_copy(lin_seg):
     copy = lin_seg.copy()
 
     # lin_seg and copy equate
-    assert lin_seg is not copy
     assert lin_seg == copy
-
-    # modifying lin_seg doesn't affect copy
-    lin_seg.p1[0] = 10
-    assert lin_seg != copy
 
 
 def test_circular_segment_creation():

--- a/pooltool/objects/table/test_components.py
+++ b/pooltool/objects/table/test_components.py
@@ -57,12 +57,21 @@ def test_linear_segment_frozen(lin_seg):
     with pytest.raises(ValueError, match="assignment destination is read-only"):
         lin_seg.p1[0] = 10
 
+    # Not bulletproof though. One can set the WRITABLE flag
+    lin_seg.p1.flags["WRITEABLE"] = True
+    lin_seg.p1[0] = 10
+
 
 def test_linear_segment_copy(lin_seg):
     copy = lin_seg.copy()
 
     # lin_seg and copy equate
     assert lin_seg == copy
+
+    # In fact, lin_seg and copy are the same object. We can get away with this because
+    # it's a frozen object with either (a) immutable attributes or (b) attributes which
+    # with read-only flags set
+    assert lin_seg is copy
 
 
 def test_circular_segment_creation():
@@ -80,7 +89,12 @@ def test_circular_segment_frozen(circ_seg):
     with pytest.raises(FrozenInstanceError):
         circ_seg.center = np.array([10, 10, 10])
 
-    # Unfortunately, this is allowed
+    # Cannot even modify array elements
+    with pytest.raises(ValueError, match="assignment destination is read-only"):
+        circ_seg.center[0] = 10
+
+    # Not bulletproof though. One can set the WRITABLE flag
+    circ_seg.center.flags["WRITEABLE"] = True
     circ_seg.center[0] = 10
 
 
@@ -88,12 +102,12 @@ def test_circular_segment_copy(circ_seg):
     copy = circ_seg.copy()
 
     # circ_seg and copy equate
-    assert circ_seg is not copy
     assert circ_seg == copy
 
-    # modifying circ_seg doesn't affect copy
-    circ_seg.center[0] = 10
-    assert circ_seg != copy
+    # In fact, circ_seg and copy are the same object. We can get away with this because
+    # it's a frozen object with either (a) immutable attributes or (b) attributes which
+    # with read-only flags set
+    assert circ_seg is copy
 
 
 def test_pocket_creation():
@@ -121,26 +135,38 @@ def test_pocket_creation():
     )
 
 
-def test_pocket_frozen(pocket):
+def test_pocket_modifiability(pocket):
+    """Test what is and isn't modifiable for Pocket"""
     # Cannot set attributes of frozen class
     with pytest.raises(FrozenInstanceError):
         pocket.center = np.array([10, 10, 10])
+    with pytest.raises(FrozenInstanceError):
+        pocket.contains = set()
 
-    # Unfortunately, this is allowed
+    # Cannot modify array elements
+    with pytest.raises(ValueError, match="assignment destination is read-only"):
+        pocket.center[0] = 10
+
+    # Not bulletproof though. One can set the WRITABLE flag
+    pocket.center.flags["WRITEABLE"] = True
     pocket.center[0] = 10
+
+    # One can however, add and subtract from `contains`
+    pocket.contains.add("dummy")
 
 
 def test_pocket_copy(pocket):
     copy = pocket.copy()
 
     # pocket and copy equate
-    assert pocket.contains is not copy.contains
-    assert pocket is not copy
     assert pocket == copy
 
-    # modifying pocket doesn't affect copy
-    pocket.center[0] = 10
-    assert pocket != copy
+    # center is read only, so its safe that they share the same reference
+    pocket.center is copy.center
+
+    # contains is mutable, so separate objects is necessary
+    assert pocket.contains == copy.contains
+    assert pocket.contains is not copy.contains
 
 
 def test_cushion_segments_copy(lin_seg, circ_seg):
@@ -150,9 +176,16 @@ def test_cushion_segments_copy(lin_seg, circ_seg):
     copy = segments.copy()
 
     # segments and copy equate
-    assert segments is not copy
     assert segments == copy
 
     # Their dictionaries are not the same
     assert segments.linear is not copy.linear
     assert segments.circular is not copy.circular
+
+    # You can't change the elements within a dictionary
+    with pytest.raises(ValueError, match="assignment destination is read-only"):
+        segments.linear[lin_seg.id].p1[0] = 4
+
+    # But you can add new elements to `copy` without changing `segments`
+    copy.linear["new"] = circ_seg
+    assert "new" not in segments.linear

--- a/pooltool/objects/table/test_datatypes.py
+++ b/pooltool/objects/table/test_datatypes.py
@@ -18,6 +18,6 @@ def test_table_copy(table):
     assert new.cushion_segments is not table.cushion_segments
     assert new.pockets is not table.pockets
 
-    # `specs` object _is_ shared, but its frozen so its OK
-    assert new.specs is table.specs
-    assert new.specs.__dataclass_params__.frozen
+    # `model_descr` object _is_ shared, but its frozen so its OK
+    assert new.model_descr is table.model_descr
+    assert new.model_descr.__dataclass_params__.frozen

--- a/pooltool/system/datatypes.py
+++ b/pooltool/system/datatypes.py
@@ -192,7 +192,7 @@ class System:
                 g=ball.params.g,
                 t=dt,
             )
-            ball.state.set(rvw, s=s, t=(self.t + dt))
+            ball.state = BallState(rvw, s, self.t + dt)
 
     def resolve_event(self, event: Event) -> None:
         if event.event_type == EventType.NONE:


### PR DESCRIPTION
Some objects like `LinearCushionSegment` serve as `Agent` objects in `Events`, and undergo copy calls whenever they are involved in an event. But these are in essence immutable objects, even though they have numpy arrays that define them. To simplify the copy routines, we can get away with returning oneself rather than creating another object, and as a safeguard against modifying them accidentally, this PR sets the `"WRITEABLE"` flag to false for said arrays.