### PR TITLE
Gzip array export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@
 sandbox/collection.json*
 sandbox/serialize/serialized_shot*
 sandbox/offscreen/offscreen_out
-sandbox/offscreen/timing/image_array*
-sandbox/offscreen/timing/image_dir*
+sandbox/offscreen/timing/*
 cachegrind*
 
 *.blend1

--- a/pooltool/ani/image/io.py
+++ b/pooltool/ani/image/io.py
@@ -1,3 +1,4 @@
+import gzip
 import re
 from pathlib import Path
 from typing import List, Union
@@ -108,3 +109,20 @@ class NpyImages:
     @staticmethod
     def read(path: Union[str, Path]) -> NDArray[np.uint8]:
         return np.load(path)
+
+
+@attrs.define
+class GzipArrayImages:
+    path: Path = attrs.field(converter=Path)
+
+    def save(self, data: DataPack) -> None:
+        with open(self.path, "wb") as fp:
+            fp.write(gzip.compress(memoryview(data.imgs), compresslevel=1))
+
+        if data.system is not None:
+            data.system.save(self.path.with_suffix(".msgpack"))
+
+    @staticmethod
+    def read(path: Union[str, Path]) -> NDArray[np.uint8]:
+        with open(path, "rb") as fp:
+            return np.frombuffer(gzip.decompress(fp.read()), dtype=np.uint8)

--- a/pooltool/ani/image/io.py
+++ b/pooltool/ani/image/io.py
@@ -1,7 +1,8 @@
 import gzip
 import re
+from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import List, Union
+from typing import Any, List, Union
 
 import attrs
 import h5py
@@ -12,8 +13,21 @@ from PIL import Image
 from pooltool.ani.image.utils import DataPack, ImageExt, gif
 
 
+class ImageIO(ABC):
+    path: Path
+
+    @abstractmethod
+    def save(self, data: DataPack) -> Any:
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def read(path: Union[str, Path]) -> NDArray[np.uint8]:
+        pass
+
+
 @attrs.define
-class ImageDir:
+class ImageDir(ImageIO):
     """Exporter for creating a directory of images"""
 
     path: Path = attrs.field(converter=Path)
@@ -79,7 +93,7 @@ class ImageDir:
 
 
 @attrs.define
-class HDF5Images:
+class HDF5Images(ImageIO):
     path: Path = attrs.field(converter=Path)
 
     def save(self, data: DataPack) -> None:
@@ -98,7 +112,7 @@ class HDF5Images:
 
 
 @attrs.define
-class NpyImages:
+class NpyImages(ImageIO):
     path: Path = attrs.field(converter=Path)
 
     def save(self, data: DataPack) -> None:
@@ -112,7 +126,7 @@ class NpyImages:
 
 
 @attrs.define
-class GzipArrayImages:
+class GzipArrayImages(ImageIO):
     path: Path = attrs.field(converter=Path)
 
     def save(self, data: DataPack) -> None:

--- a/pooltool/ani/image/io.py
+++ b/pooltool/ani/image/io.py
@@ -13,7 +13,7 @@ from PIL import Image
 from pooltool.ani.image.utils import DataPack, ImageExt, gif
 
 
-class ImageIO(ABC):
+class ImageStorageMethod(ABC):
     path: Path
 
     @abstractmethod
@@ -27,7 +27,7 @@ class ImageIO(ABC):
 
 
 @attrs.define
-class ImageDir(ImageIO):
+class ImageDir(ImageStorageMethod):
     """Exporter for creating a directory of images"""
 
     path: Path = attrs.field(converter=Path)
@@ -93,7 +93,7 @@ class ImageDir(ImageIO):
 
 
 @attrs.define
-class HDF5Images(ImageIO):
+class HDF5Images(ImageStorageMethod):
     path: Path = attrs.field(converter=Path)
 
     def save(self, data: DataPack) -> None:
@@ -112,7 +112,7 @@ class HDF5Images(ImageIO):
 
 
 @attrs.define
-class NpyImages(ImageIO):
+class NpyImages(ImageStorageMethod):
     path: Path = attrs.field(converter=Path)
 
     def save(self, data: DataPack) -> None:
@@ -126,12 +126,14 @@ class NpyImages(ImageIO):
 
 
 @attrs.define
-class GzipArrayImages(ImageIO):
+class GzipArrayImages(ImageStorageMethod):
     path: Path = attrs.field(converter=Path)
 
     def save(self, data: DataPack) -> None:
         with open(self.path, "wb") as fp:
-            fp.write(gzip.compress(memoryview(data.imgs), compresslevel=1))
+            fp.write(
+                gzip.compress(memoryview(data.imgs), compresslevel=1)  # type: ignore
+            )
 
         if data.system is not None:
             data.system.save(self.path.with_suffix(".msgpack"))

--- a/sandbox/offscreen/timing.py
+++ b/sandbox/offscreen/timing.py
@@ -20,6 +20,12 @@ ap.add_argument(
     help="How resolved should the image be? E.g. 144, 360, 480, 720",
 )
 ap.add_argument(
+    "--fps",
+    type=int,
+    default=10,
+    help="How many frames per second?",
+)
+ap.add_argument(
     "--gray",
     action="store_true",
     help="Whether image is stored as grayscale",
@@ -54,6 +60,8 @@ system.strike(V0=8)
 with pt.terminal.TimeCode("Time to simulate 9-ball break: "):
     pt.simulate(system)
 
+# -------------------------------------------------------------------------------------
+
 # Make the output directory
 path = Path(__file__).parent / "timing"
 if path.exists():
@@ -75,8 +83,10 @@ with pt.terminal.TimeCode("Time to render the images: "):
         size=(args.res * 1.6, args.res),
         show_hud=False,
         gray=args.gray,
-        fps=10,
+        fps=args.fps,
     )
+
+# -------------------------------------------------------------------------------------
 
 run = pt.terminal.Run()
 
@@ -91,7 +101,10 @@ for exporter in exporters:
         run.info(
             f"Size of {exporter.__class__.__name__}",
             human_readable_file_size(
-                sum(file.stat().st_size for file in Path(exporter.path).glob("*.png"))
+                sum(
+                    file.stat().st_size
+                    for file in Path(exporter.path).glob(f"*.{exporter.ext}")
+                )
             ),
             nl_before=1,
             nl_after=1,


### PR DESCRIPTION
Gzipped arrays offer a decent compromise between space and read times, especially for low resolution images. Kind of like JPEG except faster accession and more space.