### PR TITLE
Re-continuize when speed change is requested

### DIFF
--- a/pooltool/system/render.py
+++ b/pooltool/system/render.py
@@ -10,7 +10,7 @@ from pooltool.ani.globals import Global
 from pooltool.objects.ball.render import BallRender
 from pooltool.objects.cue.render import CueRender
 from pooltool.objects.table.render import TableRender
-from pooltool.system.datatypes import System
+from pooltool.system.datatypes import System, multisystem
 from pooltool.utils.strenum import StrEnum, auto
 
 
@@ -167,6 +167,10 @@ class SystemController:
 
         self.reset_animation(reset_pause=False)
         self.playback_speed *= factor
+
+        # Recontinuize to adjust for change in speed
+        multisystem.active.continuize(dt=0.01 * self.playback_speed)
+
         self.build_shot_animation()
 
         self.shot_animation.setPlayRate(factor * self.shot_animation.getPlayRate())


### PR DESCRIPTION
In a refactor, re-continuizing the shot to reflect the new playback speed was lost, which made animations look very unrealistic when slowed down. After recontinuizing, this fixes the issue