### PR TITLE
Small re-arrangement

### DIFF
--- a/pooltool/events/resolve.py
+++ b/pooltool/events/resolve.py
@@ -1,7 +1,7 @@
 from typing import Callable, Dict, Tuple
 
+import attrs
 import numpy as np
-from attrs import evolve
 
 import pooltool.constants as c
 import pooltool.physics as physics
@@ -27,8 +27,12 @@ def resolve_ball_ball(event: Event) -> Event:
         ball1.initial.params.R,
     )
 
-    ball1.final = evolve(ball1.initial, state=BallState(rvw1, c.sliding, event.time))
-    ball2.final = evolve(ball2.initial, state=BallState(rvw2, c.sliding, event.time))
+    ball1.final = attrs.evolve(
+        ball1.initial, state=BallState(rvw1, c.sliding, event.time)
+    )
+    ball2.final = attrs.evolve(
+        ball2.initial, state=BallState(rvw2, c.sliding, event.time)
+    )
 
     return event
 
@@ -58,7 +62,7 @@ def resolve_linear_ball_cushion(event: Event) -> Event:
         f_c=ball.initial.params.f_c,
     )
 
-    ball.final = evolve(ball.initial, state=BallState(rvw, c.sliding, event.time))
+    ball.final = attrs.evolve(ball.initial, state=BallState(rvw, c.sliding, event.time))
     cushion.final = None
 
     return event
@@ -85,7 +89,7 @@ def resolve_circular_ball_cushion(event: Event) -> Event:
         f_c=ball.initial.params.f_c,
     )
 
-    ball.final = evolve(ball.initial, state=BallState(rvw, c.sliding, event.time))
+    ball.final = attrs.evolve(ball.initial, state=BallState(rvw, c.sliding, event.time))
     cushion.final = None
 
     return event
@@ -106,7 +110,9 @@ def resolve_ball_pocket(event: Event) -> Event:
         ]
     )
 
-    ball.final = evolve(ball.initial, state=BallState(rvw, c.pocketed, event.time))
+    ball.final = attrs.evolve(
+        ball.initial, state=BallState(rvw, c.pocketed, event.time)
+    )
     pocket.final = pocket.initial.copy()
     pocket.final.add(ball.final.id)
 
@@ -133,7 +139,7 @@ def resolve_stick_ball(event: Event) -> Event:
     rvw = np.array([ball.initial.state.rvw[0], v, w])
     s = c.sliding
 
-    ball.final = evolve(ball.initial, state=BallState(rvw, s, event.time))
+    ball.final = attrs.evolve(ball.initial, state=BallState(rvw, s, event.time))
     cue.final = None
 
     return event

--- a/pooltool/system/datatypes.py
+++ b/pooltool/system/datatypes.py
@@ -251,8 +251,19 @@ class System:
 
         assert self.cue.cue_ball_id in self.balls
 
-        event = stick_ball_collision(self.cue, self.balls[self.cue.cue_ball_id], time=0)
-        self.resolve_event(event)
+        event = stick_ball_collision(
+            stick=self.cue,
+            ball=self.balls[self.cue.cue_ball_id],
+            time=0,
+            set_initial=True,
+        )
+
+        event = resolve_event(event)
+
+        # Set the stricken ball's state
+        final = event.agents[1].get_final()
+        assert isinstance(final, Ball)
+        self.balls[final.id].state = final.state
 
     def aim_at_pos(self, pos):
         """Set phi to aim at a 3D position

--- a/pooltool/system/datatypes.py
+++ b/pooltool/system/datatypes.py
@@ -10,17 +10,9 @@ from attrs import define, field
 import pooltool.math as math
 import pooltool.physics as physics
 from pooltool.error import ConfigError
-from pooltool.events import (
-    AgentType,
-    Event,
-    EventType,
-    filter_ball,
-    resolve_event,
-    stick_ball_collision,
-)
+from pooltool.events import Event, filter_ball, resolve_event, stick_ball_collision
 from pooltool.objects.ball.datatypes import Ball, BallHistory, BallState
 from pooltool.objects.cue.datatypes import Cue
-from pooltool.objects.table.components import Pocket
 from pooltool.objects.table.datatypes import Table
 from pooltool.potting import PottingConfig
 from pooltool.serialize import conversion
@@ -202,35 +194,6 @@ class System:
                 t=dt,
             )
             ball.state = BallState(rvw, s, self.t + dt)
-
-    def resolve_event(self, event: Event) -> None:
-        if event.event_type == EventType.NONE:
-            return
-
-        # The system has evolved since the event was created, so the initial states need
-        # to be snapshotted according to the current state
-        for agent in event.agents:
-            if agent.agent_type == AgentType.CUE:
-                agent.set_initial(self.cue)
-            elif agent.agent_type == AgentType.BALL:
-                agent.set_initial(self.balls[agent.id])
-            elif agent.agent_type == AgentType.POCKET:
-                agent.set_initial(self.table.pockets[agent.id])
-            elif agent.agent_type == AgentType.LINEAR_CUSHION_SEGMENT:
-                agent.set_initial(self.table.cushion_segments.linear[agent.id])
-            elif agent.agent_type == AgentType.CIRCULAR_CUSHION_SEGMENT:
-                agent.set_initial(self.table.cushion_segments.circular[agent.id])
-
-        event = resolve_event(event)
-
-        # The final states of the agents are solved, but the system objects still need
-        # to be updated with these states.
-        for agent in event.agents:
-            final = agent.get_final()
-            if isinstance(final, Ball):
-                self.balls[final.id].state = final.state
-            elif isinstance(final, Pocket):
-                self.table.pockets[final.id] = final
 
     def reset_balls(self):
         """Reset balls to their initial states"""


### PR DESCRIPTION
To begin the process of making the physics modular, I'm starting small: moving the `resolve_event` method of `System` into `pooltool.simulate.event_based.simulate.py`.

The reason for this is because I want to treat `System` as more of a dataclass than a behavioral class. When the physics is customizable, I don't want `System.resolve_event` to accept some physics config that specifies to `System` how it's events should be resolved. That is strictly the responsibility of the shot evolution algorithm (hence `pooltool.simulate.event_based.simulate.py`).