### PR TITLE
Another small rearrangement

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ shot = pt.System(table=table, balls=balls, cue=cue)
 shot.aim_at_ball("1")
 shot.strike(V0=8)
 
-# Evolve the shot. This modifies the system in-place
+# Evolve the shot.
 pt.simulate(shot, inplace=True)
 
 # Open up the shot in the GUI

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ shot.aim_at_ball("1")
 shot.strike(V0=8)
 
 # Evolve the shot. This modifies the system in-place
-pt.simulate(shot)
+pt.simulate(shot, inplace=True)
 
 # Open up the shot in the GUI
 interface.show(shot)

--- a/pooltool/__init__.py
+++ b/pooltool/__init__.py
@@ -30,7 +30,7 @@ from pooltool.events import (
     spinning_stationary_transition,
     stick_ball_collision,
 )
-from pooltool.evolution import simulate
+from pooltool.evolution import continuize, simulate
 from pooltool.layouts import (
     get_eight_ball_rack,
     get_nine_ball_rack,

--- a/pooltool/ani/animate.py
+++ b/pooltool/ani/animate.py
@@ -246,7 +246,7 @@ class FrameStepper(Interface):
         size: Tuple[int, int] = (int(1.6 * 720), 720),
         fps: float = 30.0,
     ) -> Generator:
-        continuize(system, 1 / fps)
+        continuize(system, dt=1 / fps, inplace=True)
 
         multisystem.reset()
         multisystem.append(system)

--- a/pooltool/ani/animate.py
+++ b/pooltool/ani/animate.py
@@ -30,6 +30,7 @@ from pooltool.ani.hud import HUDElement, hud
 from pooltool.ani.menu import GenericMenu, menus
 from pooltool.ani.modes import Mode, ModeManager, all_modes
 from pooltool.ani.mouse import mouse
+from pooltool.evolution.continuize import continuize
 from pooltool.objects.ball.datatypes import BallParams
 from pooltool.objects.cue.datatypes import Cue
 from pooltool.objects.table.datatypes import Table
@@ -245,7 +246,7 @@ class FrameStepper(Interface):
         size: Tuple[int, int] = (int(1.6 * 720), 720),
         fps: float = 30.0,
     ) -> Generator:
-        system.continuize(dt=1 / fps)
+        continuize(system, 1 / fps)
 
         multisystem.reset()
         multisystem.append(system)

--- a/pooltool/ani/modes/calculate.py
+++ b/pooltool/ani/modes/calculate.py
@@ -80,6 +80,7 @@ class CalculateMode(BaseMode):
         simulate(
             multisystem.active,
             continuous=True,
+            inplace=True,
         )
 
         Global.game.process_shot(multisystem.active)

--- a/pooltool/ani/modes/calculate.py
+++ b/pooltool/ani/modes/calculate.py
@@ -79,7 +79,7 @@ class CalculateMode(BaseMode):
 
         simulate(
             multisystem.active,
-            continuize=True,
+            continuous=True,
         )
 
         Global.game.process_shot(multisystem.active)

--- a/pooltool/evolution/__init__.py
+++ b/pooltool/evolution/__init__.py
@@ -1,3 +1,4 @@
+from pooltool.evolution.continuize import continuize
 from pooltool.evolution.event_based.simulate import simulate as simulate_event_based
 
 simulate = simulate_event_based

--- a/pooltool/evolution/continuize.py
+++ b/pooltool/evolution/continuize.py
@@ -1,0 +1,111 @@
+import pooltool.physics as physics
+from pooltool.events import filter_ball
+from pooltool.objects.ball.datatypes import BallHistory, BallState
+from pooltool.system.datatypes import System
+
+
+def continuize(system: System, dt: float = 0.01) -> None:
+    """Create BallHistory for each ball with many timepoints
+
+    All balls share the same timepoints, and the timepoints are uniformly spaced, except
+    for the last timepoint, which occurs within <dt of the second last timepoint.
+
+    The old continuize did not have uniform and equally spaced time points. That
+    implementation can be found with
+
+        git checkout 7b2f7440f7d9ad18cba65c9e4862ee6bdc620631
+
+    (Look for pooltool.system.datatypes.continuize_heterogeneous)
+
+    FIXME This is a very inefficient function, and could be
+    radically sped up if physics.evolve_ball_motion and/or its functions had
+    vectorized operations for arrays of time values.
+    """
+
+    # This is the exact number of timepoints that the ball histories will contain
+    num_timestamps = int(system.events[-1].time // dt) + 1
+
+    for ball in system.balls.values():
+        # Create a new history and add the zeroth event
+        history = BallHistory()
+        history.add(ball.history[0])
+
+        rvw, s = ball.history[0].rvw, ball.history[0].s
+
+        # Get all events that the ball is involved in, even the null_event events
+        # that mark the start and end times
+        events = filter_ball(system.events, ball.id, keep_nonevent=True)
+
+        # Tracks which event is currently being handled
+        count = 0
+
+        # The elapsed simulation time (as of the last timepoint)
+        elapsed = 0.0
+
+        for n in range(num_timestamps):
+            if n == (num_timestamps - 1):
+                # We made it to the end. the difference between the final time and
+                # the elapsed time should be < dt
+                assert events[-1].time - elapsed < dt
+                break
+
+            if events[count + 1].time - elapsed > dt:
+                # This is the easy case. There is no upcoming event so we simply
+                # evolve the state an amount dt
+                evolve_time = dt
+
+            else:
+                # The next event (and perhaps an arbitrary number of subsequent
+                # events) occurs before the next timestamp. Find the last event
+                # between the current timestamp and the next timestamp. This will be
+                # used as a launching point to simulate the ball state to the next
+                # timestamp
+
+                while True:
+                    count += 1
+
+                    if events[count + 1].time - elapsed > dt:
+                        # OK, we found the last event between the current timestamp
+                        # and the next timestamp. It is events[count].
+                        break
+
+                # We need to get the ball's outgoing state from the event. We'll
+                # evolve the system from this state.
+                for agent in events[count].agents:
+                    if agent.matches(ball):
+                        state = agent.get_final().state
+                        break
+                else:
+                    raise ValueError("No agents in event match ball")
+
+                rvw, s = state.rvw, state.s
+
+                # Since this event occurs between two timestamps, we won't be
+                # evolving a full dt. Instead, we evolve this much:
+                evolve_time = elapsed + dt - events[count].time
+
+            # Whether it was the hard path or the easy path, the ball state is
+            # properly defined and we know how much we need to simulate.
+            rvw, s = physics.evolve_ball_motion(
+                state=s,
+                rvw=rvw,
+                R=ball.params.R,
+                m=ball.params.m,
+                u_s=ball.params.u_s,
+                u_sp=ball.params.u_sp,
+                u_r=ball.params.u_r,
+                g=ball.params.g,
+                t=evolve_time,
+            )
+
+            history.add(BallState(rvw, s, elapsed + dt))
+            elapsed += dt
+
+        # There is a finale. The final state is missing from the continuous history,
+        # whose final state is within dt of the true final state. We add the final
+        # state to the continous history even though this breaks the promise of
+        # uniformly spaced timestamps
+        history.add(ball.history[-1])
+
+        # Attach the newly created history to the ball
+        ball.history_cts = history

--- a/pooltool/evolution/continuize.py
+++ b/pooltool/evolution/continuize.py
@@ -39,7 +39,7 @@ def continuize(system: System, dt: float = 0.01, inplace: bool = False) -> Syste
         >>> # Continuize a system in place
         >>> import pooltool as pt
         >>> system = pt.simulate(pt.System.example())
-        >>> continuized_system = pt.continuize(system, inplace=False)
+        >>> continuized_system = pt.continuize(system, inplace=True)
         >>> assert system.continuized
         >>> assert continuized_system.continuized
         >>> assert system is continuized_system

--- a/pooltool/evolution/event_based/simulate.py
+++ b/pooltool/evolution/event_based/simulate.py
@@ -143,7 +143,7 @@ def simulate(
             break
 
     if continuous:
-        continuize(shot, 0.01 if dt is None else dt)
+        continuize(shot, dt=0.01 if dt is None else dt, inplace=True)
 
     return shot
 

--- a/pooltool/evolution/event_based/simulate.py
+++ b/pooltool/evolution/event_based/simulate.py
@@ -26,6 +26,7 @@ from pooltool.events import (
     sliding_rolling_transition,
     spinning_stationary_transition,
 )
+from pooltool.evolution.continuize import continuize
 from pooltool.evolution.event_based import solve
 from pooltool.evolution.event_based.config import INCLUDED_EVENTS
 from pooltool.math.roots.quartic import QuarticSolver
@@ -43,7 +44,7 @@ def simulate(
     include: Set[EventType] = INCLUDED_EVENTS,
     quartic_solver: QuarticSolver = QuarticSolver.HYBRID,
     t_final=None,
-    continuize=False,
+    continuous=False,
     dt=None,
 ) -> System:
     """Run a simulation on a system and return it"""
@@ -77,8 +78,8 @@ def simulate(
             shot.update_history(null_event(time=shot.t))
             break
 
-    if continuize:
-        shot.continuize(dt=dt)
+    if continuous:
+        continuize(shot, dt)
 
     return shot
 

--- a/pooltool/evolution/event_based/test_simulate.py
+++ b/pooltool/evolution/event_based/test_simulate.py
@@ -9,12 +9,67 @@ from pooltool.events import EventType, ball_ball_collision, ball_pocket_collisio
 from pooltool.evolution.event_based.simulate import (
     get_next_ball_ball_collision,
     get_next_event,
+    simulate,
 )
 from pooltool.evolution.event_based.solve import ball_ball_collision_coeffs
 from pooltool.evolution.event_based.test_data import TEST_DIR
 from pooltool.math.roots import quadratic, quartic
 from pooltool.objects import Ball, BilliardTableSpecs, Cue, Table
 from pooltool.system import System
+
+
+def test_simulate_inplace():
+    # First, we don't modify in place
+    system = System.example()
+    simulated_system = simulate(system, inplace=False)
+
+    # The passed system is not simulated
+    assert not system.simulated
+
+    # The returned system is
+    assert simulated_system.simulated
+
+    # The passed system is not the returned system
+    assert system is not simulated_system
+
+    # Now, we modify in place
+    system = System.example()
+    simulated_system = simulate(system, inplace=True)
+
+    # The passed system is simulated
+    assert system.simulated
+
+    # The returned system is simulated
+    assert simulated_system.simulated
+
+    # The passed system is the returned system
+    assert system is simulated_system
+
+
+def test_simulate_continuize():
+    system = System.example()
+    simulate(system, inplace=True, continuous=False)
+
+    # System is not continuized
+    assert not system.continuized
+
+    for ball in system.balls.values():
+        # history_cts is empty
+        assert len(ball.history_cts) == 0
+        # history is not
+        assert len(ball.history) > 0
+
+    system = System.example()
+    simulate(system, inplace=True, continuous=True)
+
+    # System is continuized
+    assert system.continuized
+
+    for ball in system.balls.values():
+        # history_cts is populated
+        assert len(ball.history_cts) > 0
+        # history is too
+        assert len(ball.history) > 0
 
 
 @pytest.mark.parametrize(

--- a/pooltool/evolution/test_continuize.py
+++ b/pooltool/evolution/test_continuize.py
@@ -1,0 +1,32 @@
+from pooltool.evolution.continuize import continuize
+from pooltool.evolution.event_based.simulate import simulate
+from pooltool.system import System
+
+
+def test_continuize_inplace():
+    # Simulate a system
+    system = simulate(System.example())
+
+    # Now continuize it (no inplace)
+    continuized_system = continuize(system, inplace=False)
+
+    # Passed system is not continuized
+    assert not system.continuized
+
+    # Returned system is
+    assert continuized_system.continuized
+
+    # Simulate another system
+    system = simulate(System.example())
+
+    # Now continuize it (inplace)
+    continuized_system = continuize(system, inplace=True)
+
+    # Passed system is continuized
+    assert system.continuized
+
+    # Returned system is continuized
+    assert continuized_system.continuized
+
+    # They are the same object
+    assert continuized_system is system

--- a/pooltool/objects/cue/datatypes.py
+++ b/pooltool/objects/cue/datatypes.py
@@ -29,7 +29,7 @@ class Cue:
     theta: float = field(default=0.0)
     a: float = field(default=0.0)
     b: float = field(default=0.25)
-    cue_ball_id: Optional[str] = field(default=None)
+    cue_ball_id: Optional[str] = field(default="cue")
 
     specs: CueSpecs = field(factory=CueSpecs.default)
 

--- a/pooltool/system/datatypes.py
+++ b/pooltool/system/datatypes.py
@@ -10,120 +10,13 @@ from attrs import define, field
 import pooltool.math as math
 import pooltool.physics as physics
 from pooltool.error import ConfigError
-from pooltool.events import Event, filter_ball, resolve_event, stick_ball_collision
+from pooltool.events import Event, resolve_event, stick_ball_collision
 from pooltool.objects.ball.datatypes import Ball, BallHistory, BallState
 from pooltool.objects.cue.datatypes import Cue
 from pooltool.objects.table.datatypes import Table
 from pooltool.potting import PottingConfig
 from pooltool.serialize import conversion
 from pooltool.serialize.serializers import Pathish
-
-
-def continuize(system: System, dt: float = 0.01) -> None:
-    """Create BallHistory for each ball with many timepoints
-
-    All balls share the same timepoints, and the timepoints are uniformly spaced, except
-    for the last timepoint, which occurs within <dt of the second last timepoint.
-
-    The old continuize did not have uniform and equally spaced time points. That
-    implementation can be found with
-
-        git checkout 7b2f7440f7d9ad18cba65c9e4862ee6bdc620631
-
-    (Look for pooltool.system.datatypes.continuize_heterogeneous)
-
-    FIXME This is a very inefficient function, and could be
-    radically sped up if physics.evolve_ball_motion and/or its functions had
-    vectorized operations for arrays of time values.
-    """
-
-    # This is the exact number of timepoints that the ball histories will contain
-    num_timestamps = int(system.events[-1].time // dt) + 1
-
-    for ball in system.balls.values():
-        # Create a new history and add the zeroth event
-        history = BallHistory()
-        history.add(ball.history[0])
-
-        rvw, s = ball.history[0].rvw, ball.history[0].s
-
-        # Get all events that the ball is involved in, even the null_event events
-        # that mark the start and end times
-        events = filter_ball(system.events, ball.id, keep_nonevent=True)
-
-        # Tracks which event is currently being handled
-        count = 0
-
-        # The elapsed simulation time (as of the last timepoint)
-        elapsed = 0.0
-
-        for n in range(num_timestamps):
-            if n == (num_timestamps - 1):
-                # We made it to the end. the difference between the final time and
-                # the elapsed time should be < dt
-                assert events[-1].time - elapsed < dt
-                break
-
-            if events[count + 1].time - elapsed > dt:
-                # This is the easy case. There is no upcoming event so we simply
-                # evolve the state an amount dt
-                evolve_time = dt
-
-            else:
-                # The next event (and perhaps an arbitrary number of subsequent
-                # events) occurs before the next timestamp. Find the last event
-                # between the current timestamp and the next timestamp. This will be
-                # used as a launching point to simulate the ball state to the next
-                # timestamp
-
-                while True:
-                    count += 1
-
-                    if events[count + 1].time - elapsed > dt:
-                        # OK, we found the last event between the current timestamp
-                        # and the next timestamp. It is events[count].
-                        break
-
-                # We need to get the ball's outgoing state from the event. We'll
-                # evolve the system from this state.
-                for agent in events[count].agents:
-                    if agent.matches(ball):
-                        state = agent.get_final().state
-                        break
-                else:
-                    raise ValueError("No agents in event match ball")
-
-                rvw, s = state.rvw, state.s
-
-                # Since this event occurs between two timestamps, we won't be
-                # evolving a full dt. Instead, we evolve this much:
-                evolve_time = elapsed + dt - events[count].time
-
-            # Whether it was the hard path or the easy path, the ball state is
-            # properly defined and we know how much we need to simulate.
-            rvw, s = physics.evolve_ball_motion(
-                state=s,
-                rvw=rvw,
-                R=ball.params.R,
-                m=ball.params.m,
-                u_s=ball.params.u_s,
-                u_sp=ball.params.u_sp,
-                u_r=ball.params.u_r,
-                g=ball.params.g,
-                t=evolve_time,
-            )
-
-            history.add(BallState(rvw, s, elapsed + dt))
-            elapsed += dt
-
-        # There is a finale. The final state is missing from the continuous history,
-        # whose final state is within dt of the true final state. We add the final
-        # state to the continous history even though this breaks the promise of
-        # uniformly spaced timestamps
-        history.add(ball.history[-1])
-
-        # Attach the newly created history to the ball
-        ball.history_cts = history
 
 
 @define
@@ -168,10 +61,6 @@ class System:
             ball.state.t = 0
 
         self.events = []
-
-    def continuize(self, dt: float = 0.01):
-        """Create BallHistory for each ball with many timepoints"""
-        continuize(self, dt=dt)
 
     def evolve(self, dt: float):
         """Evolves current ball an amount of time dt

--- a/pooltool/system/datatypes.py
+++ b/pooltool/system/datatypes.py
@@ -331,6 +331,20 @@ class System:
     def load(cls, path: Pathish) -> System:
         return conversion.structure_from(path, cls)
 
+    @classmethod
+    def example(cls) -> System:
+        system = cls(
+            cue=Cue.default(),
+            table=(table := Table.default()),
+            balls={
+                "cue": Ball.create("cue", xy=(table.w / 2, table.l / 2)),
+                "1": Ball.create("1", xy=(table.w / 2, 3 / 4 * table.l)),
+            },
+        )
+        system.aim_for_best_pocket("1")
+        system.strike(V0=1.5, b=-0.3)
+        return system
+
 
 @define
 class MultiSystem:

--- a/pooltool/system/render.py
+++ b/pooltool/system/render.py
@@ -7,6 +7,7 @@ from direct.interval.IntervalGlobal import Func, Parallel, Sequence, Wait
 from panda3d.direct import HideInterval, ShowInterval
 
 from pooltool.ani.globals import Global
+from pooltool.evolution.continuize import continuize
 from pooltool.objects.ball.render import BallRender
 from pooltool.objects.cue.render import CueRender
 from pooltool.objects.table.render import TableRender
@@ -25,7 +26,7 @@ class SystemRender:
         # If you're making a SystemRender from your system that has already been
         # simulated, you want it continuized
         if system.simulated and not system.continuized:
-            system.continuize()
+            continuize(system)
 
         return SystemRender(
             balls={ball_id: BallRender(ball) for ball_id, ball in system.balls.items()},
@@ -169,7 +170,7 @@ class SystemController:
         self.playback_speed *= factor
 
         # Recontinuize to adjust for change in speed
-        multisystem.active.continuize(dt=0.01 * self.playback_speed)
+        continuize(multisystem.active, 0.01 * self.playback_speed)
 
         self.build_shot_animation()
 

--- a/pooltool/system/render.py
+++ b/pooltool/system/render.py
@@ -26,7 +26,7 @@ class SystemRender:
         # If you're making a SystemRender from your system that has already been
         # simulated, you want it continuized
         if system.simulated and not system.continuized:
-            continuize(system)
+            continuize(system, inplace=True)
 
         return SystemRender(
             balls={ball_id: BallRender(ball) for ball_id, ball in system.balls.items()},
@@ -170,7 +170,7 @@ class SystemController:
         self.playback_speed *= factor
 
         # Recontinuize to adjust for change in speed
-        continuize(multisystem.active, 0.01 * self.playback_speed)
+        continuize(multisystem.active, dt=0.01 * self.playback_speed, inplace=True)
 
         self.build_shot_animation()
 

--- a/sandbox/arena.py
+++ b/sandbox/arena.py
@@ -45,7 +45,7 @@ def main(args):
         shot.strike(V0=40)
 
         # Evolve the shot
-        pt.simulate(shot, continuous=False)
+        pt.simulate(shot, continuous=False, inplace=True)
 
         if not args.no_viz:
             interface.show(shot)

--- a/sandbox/arena.py
+++ b/sandbox/arena.py
@@ -32,7 +32,7 @@ def main(args):
         interface = pt.ShotViewer()
     while True:
         # Setup the system
-        table = pt.Table.from_table_specs(pt.PocketTableSpecs(l=4, w=2))
+        table = pt.Table.from_table_specs(pt.BilliardTableSpecs(l=4, w=2))
         balls = {}
         balls["cue"] = place_ball("cue", balls, table)
         for i in range(args.N):
@@ -45,10 +45,7 @@ def main(args):
         shot.strike(V0=40)
 
         # Evolve the shot
-        try:
-            pt.simulate(shot, continuize=False, quiet=False)
-        except KeyboardInterrupt:
-            break
+        pt.simulate(shot, continuous=False)
 
         if not args.no_viz:
             interface.show(shot)

--- a/sandbox/break.py
+++ b/sandbox/break.py
@@ -39,14 +39,14 @@ def main(args):
 
         # Burn a run (numba cache loading)
         copy = shot.copy()
-        pt.simulate(copy)
+        pt.simulate(copy, inplace=True)
         pt.continuize(copy)
 
         for i in range(N):
             copy = shot.copy()
 
             with pt.terminal.TimeCode(quiet=True) as timer:
-                pt.simulate(copy)
+                pt.simulate(copy, inplace=True)
             simulate_times[i] = timer.time.total_seconds()
 
             with pt.terminal.TimeCode(quiet=True) as timer:
@@ -69,20 +69,20 @@ def main(args):
     if args.profile_it:
         # Burn a run (numba cache loading)
         copy = shot.copy()
-        pt.simulate(copy)
+        pt.simulate(copy, inplace=True)
 
         run = pt.terminal.Run()
         run.info_single("Profiling `simulate` and `continuize` (may take awhile)")
 
         with pt.utils.PProfile(Path("cachegrind.out.simulate")):
-            pt.simulate(shot)
+            pt.simulate(shot, inplace=True)
         with pt.utils.PProfile(Path("cachegrind.out.continuize")):
             pt.continuize(shot)
 
         sys.exit()
 
     # Evolve the shot
-    pt.simulate(shot)
+    pt.simulate(shot, inplace=True)
 
     if not args.no_viz:
         interface.show(shot)

--- a/sandbox/break.py
+++ b/sandbox/break.py
@@ -40,7 +40,7 @@ def main(args):
         # Burn a run (numba cache loading)
         copy = shot.copy()
         pt.simulate(copy)
-        copy.continuize()
+        pt.continuize(copy)
 
         for i in range(N):
             copy = shot.copy()
@@ -50,7 +50,7 @@ def main(args):
             simulate_times[i] = timer.time.total_seconds()
 
             with pt.terminal.TimeCode(quiet=True) as timer:
-                copy.continuize()
+                pt.continuize(copy)
             continuize_times[i] = timer.time.total_seconds()
 
         run = pt.terminal.Run()
@@ -77,7 +77,7 @@ def main(args):
         with pt.utils.PProfile(Path("cachegrind.out.simulate")):
             pt.simulate(shot)
         with pt.utils.PProfile(Path("cachegrind.out.continuize")):
-            shot.continuize()
+            pt.continuize(shot)
 
         sys.exit()
 

--- a/sandbox/break.py
+++ b/sandbox/break.py
@@ -38,11 +38,13 @@ def main(args):
         continuize_times = np.zeros(N)
 
         # Burn a run (numba cache loading)
-        copy = shot.copy()
-        pt.simulate(copy, inplace=True)
-        pt.continuize(copy)
+        pt.simulate(shot)
+        pt.continuize(shot)
 
         for i in range(N):
+            # In what follows, copy beforehand and use inplace=True to avoid timing the
+            # copy operation
+
             copy = shot.copy()
 
             with pt.terminal.TimeCode(quiet=True) as timer:
@@ -50,7 +52,7 @@ def main(args):
             simulate_times[i] = timer.time.total_seconds()
 
             with pt.terminal.TimeCode(quiet=True) as timer:
-                pt.continuize(copy)
+                pt.continuize(copy, inplace=True)
             continuize_times[i] = timer.time.total_seconds()
 
         run = pt.terminal.Run()
@@ -77,7 +79,7 @@ def main(args):
         with pt.utils.PProfile(Path("cachegrind.out.simulate")):
             pt.simulate(shot, inplace=True)
         with pt.utils.PProfile(Path("cachegrind.out.continuize")):
-            pt.continuize(shot)
+            pt.continuize(shot, inplace=True)
 
         sys.exit()
 

--- a/sandbox/break.py
+++ b/sandbox/break.py
@@ -38,8 +38,7 @@ def main(args):
         continuize_times = np.zeros(N)
 
         # Burn a run (numba cache loading)
-        pt.simulate(shot)
-        pt.continuize(shot)
+        pt.simulate(shot, continuous=True)
 
         for i in range(N):
             # In what follows, copy beforehand and use inplace=True to avoid timing the

--- a/sandbox/break_forever.py
+++ b/sandbox/break_forever.py
@@ -22,7 +22,7 @@ def main(args):
         shot.strike(V0=args.V0)
 
         # Evolve the shot
-        pt.simulate(shot)
+        pt.simulate(shot, inplace=True)
 
         count += 1
         print(count)

--- a/sandbox/collection.py
+++ b/sandbox/collection.py
@@ -22,7 +22,7 @@ for x in np.linspace(0, 0.7, 20):
     shot = system.copy()
     shot.cue.set_state(b=-x)
     shot.strike()
-    pt.simulate(shot)
+    pt.simulate(shot, inplace=True)
     collection.append(shot)
 
 # Just showing off that you can save and load the multisystem

--- a/sandbox/continuize_and_render_timer.py
+++ b/sandbox/continuize_and_render_timer.py
@@ -13,12 +13,12 @@ def main(args):
 
     # Burn a simulation to pre-load numba caches
     copy = shot.copy()
-    pt.simulate(copy)
+    pt.simulate(copy, inplace=True)
     pt.continuize(copy)
 
     if args.profile_it:
         with pt.utils.PProfile(path=Path("cachegrind.out.simulate")):
-            pt.simulate(shot)
+            pt.simulate(shot, inplace=True)
 
         with pt.utils.PProfile(path=Path("cachegrind.out.continuize")):
             pt.continuize(shot)
@@ -35,7 +35,7 @@ def main(args):
         interface.show(shot)
 
     with pt.terminal.TimeCode(success_msg="Trajectories simulated in: "):
-        pt.simulate(shot)
+        pt.simulate(shot, inplace=True)
 
     with pt.terminal.TimeCode(success_msg="Trajectories continuized in: "):
         pt.continuize(shot)

--- a/sandbox/continuize_and_render_timer.py
+++ b/sandbox/continuize_and_render_timer.py
@@ -14,14 +14,14 @@ def main(args):
     # Burn a simulation to pre-load numba caches
     copy = shot.copy()
     pt.simulate(copy)
-    copy.continuize()
+    pt.continuize(copy)
 
     if args.profile_it:
         with pt.utils.PProfile(path=Path("cachegrind.out.simulate")):
             pt.simulate(shot)
 
         with pt.utils.PProfile(path=Path("cachegrind.out.continuize")):
-            shot.continuize()
+            pt.continuize(shot)
 
         class TimedModeManager(ModeManager):
             def change_mode(self, *args, **kwargs):
@@ -38,7 +38,7 @@ def main(args):
         pt.simulate(shot)
 
     with pt.terminal.TimeCode(success_msg="Trajectories continuized in: "):
-        shot.continuize()
+        pt.continuize(shot)
 
     class TimedModeManager(ModeManager):
         def change_mode(self, *args, **kwargs):

--- a/sandbox/continuize_and_render_timer.py
+++ b/sandbox/continuize_and_render_timer.py
@@ -14,14 +14,14 @@ def main(args):
     # Burn a simulation to pre-load numba caches
     copy = shot.copy()
     pt.simulate(copy, inplace=True)
-    pt.continuize(copy)
+    pt.continuize(copy, inplace=True)
 
     if args.profile_it:
         with pt.utils.PProfile(path=Path("cachegrind.out.simulate")):
             pt.simulate(shot, inplace=True)
 
         with pt.utils.PProfile(path=Path("cachegrind.out.continuize")):
-            pt.continuize(shot)
+            pt.continuize(shot, inplace=True)
 
         class TimedModeManager(ModeManager):
             def change_mode(self, *args, **kwargs):
@@ -38,7 +38,7 @@ def main(args):
         pt.simulate(shot, inplace=True)
 
     with pt.terminal.TimeCode(success_msg="Trajectories continuized in: "):
-        pt.continuize(shot)
+        pt.continuize(shot, inplace=True)
 
     class TimedModeManager(ModeManager):
         def change_mode(self, *args, **kwargs):

--- a/sandbox/copy_save_load.py
+++ b/sandbox/copy_save_load.py
@@ -21,7 +21,7 @@ def main():
     shot.strike(V0=8)
 
     # Simulate
-    pt.simulate(shot)
+    pt.simulate(shot, inplace=True)
 
     # Visualize it
     interface.show(shot, title="Original system state")

--- a/sandbox/offscreen/offscreen.py
+++ b/sandbox/offscreen/offscreen.py
@@ -30,7 +30,7 @@ def main(args):
     system.strike(V0=args.V0)
 
     # Evolve the shot
-    pt.simulate(system)
+    pt.simulate(system, inplace=True)
 
     # Make an dump dir
     path = Path(__file__).parent / "offscreen_out"

--- a/sandbox/offscreen/timing.py
+++ b/sandbox/offscreen/timing.py
@@ -71,11 +71,11 @@ system.aim_at_ball(ball_id="1")
 system.strike(V0=8)
 
 # Simulate the system once to load cached numba functions
-pt.simulate(system.copy())
+pt.simulate(system, inplace=False)
 
 # Time shot simulation
 with pt.terminal.TimeCode(quiet=True) as t:
-    pt.simulate(system)
+    pt.simulate(system, inplace=True)
 sim_time = t.time.total_seconds()
 
 # -------------------------------------------------------------------------------------

--- a/sandbox/serialize/demo_round_trip.py
+++ b/sandbox/serialize/demo_round_trip.py
@@ -18,7 +18,7 @@ shot.aim_at_ball(ball_id="1")
 shot.strike(V0=8)
 
 # Evolve the shot
-pt.simulate(shot)
+pt.simulate(shot, inplace=True)
 
 json_path = Path(__file__).parent / "serialized_shot.json"
 msgpack_path = Path(__file__).parent / "serialized_shot.msgpack"

--- a/sandbox/serialize/speed.py
+++ b/sandbox/serialize/speed.py
@@ -22,7 +22,7 @@ shot.strike(V0=8)
 
 # Evolve the shot
 pt.simulate(shot, inplace=True)
-pt.continuize(shot)
+pt.continuize(shot, inplace=True)
 
 json_path = Path(__file__).parent / "serialized_shot.json"
 msgpack_path = Path(__file__).parent / "serialized_shot.msgpack"

--- a/sandbox/serialize/speed.py
+++ b/sandbox/serialize/speed.py
@@ -21,7 +21,7 @@ shot.aim_at_ball(ball_id="1")
 shot.strike(V0=8)
 
 # Evolve the shot
-pt.simulate(shot)
+pt.simulate(shot, inplace=True)
 pt.continuize(shot)
 
 json_path = Path(__file__).parent / "serialized_shot.json"

--- a/sandbox/serialize/speed.py
+++ b/sandbox/serialize/speed.py
@@ -22,7 +22,7 @@ shot.strike(V0=8)
 
 # Evolve the shot
 pt.simulate(shot)
-shot.continuize()
+pt.continuize(shot)
 
 json_path = Path(__file__).parent / "serialized_shot.json"
 msgpack_path = Path(__file__).parent / "serialized_shot.msgpack"

--- a/sandbox/simple.py
+++ b/sandbox/simple.py
@@ -57,7 +57,7 @@ assert shot.get_system_energy() > 0
 assert shot.t == 0
 
 # Let's simulate the shot
-pt.simulate(shot)
+pt.simulate(shot, inplace=True)
 
 # The shot has been simulated. Here are the series of events that took place:
 print(shot.events)


### PR DESCRIPTION
This is another small rearrangement that is relatively unrelated to physics modularization.

- `continuize` has been removed as a method of `System`. This is in alignment with the push to keep `System` as a data storage, not a behavioral class.
- `continuize` has been moved into it's own module, `pooltool.evolution.continuize`. Tests have been added.
- `continuize` and `simulate` now have an inplace argument which adds clarity to how they operate. Docstrings have been added with examples.