### PR TITLE
Engine config

### DIFF
--- a/pooltool/config/README.md
+++ b/pooltool/config/README.md
@@ -1,0 +1,1 @@
+FIXME Any user-configurable settings should be moved into `$HOME/.config/pooltool` and declared via `from pooltool.user_config import CONFIG_DIR`

--- a/pooltool/evolution/continuize.py
+++ b/pooltool/evolution/continuize.py
@@ -116,7 +116,7 @@ def continuize(system: System, dt: float = 0.01, inplace: bool = False) -> Syste
                 # evolve the system from this state.
                 for agent in events[count].agents:
                     if agent.matches(ball):
-                        state = agent.final.state.copy()
+                        state = agent.final.state.copy()  # type: ignore
                         break
                 else:
                     raise ValueError("No agents in event match ball")

--- a/pooltool/physics/resolve/ball_ball/__init__.py
+++ b/pooltool/physics/resolve/ball_ball/__init__.py
@@ -1,7 +1,33 @@
+from typing import Dict, Optional, Protocol, Tuple, Type
+
+from pooltool.objects.ball.datatypes import Ball
 from pooltool.physics.resolve.ball_ball.frictionless_elastic import FrictionlessElastic
+from pooltool.utils.strenum import StrEnum, auto
+
+
+class BallBallCollisionStrategy(Protocol):
+    def resolve(
+        self, ball1: Ball, ball2: Ball, inplace: bool = False
+    ) -> Tuple[Ball, Ball]:
+        ...
+
+
+class BallBallModel(StrEnum):
+    FRICTIONLESS_ELASTIC = auto()
+
+
+_ball_ball_models: Dict[BallBallModel, Type[BallBallCollisionStrategy]] = {
+    BallBallModel.FRICTIONLESS_ELASTIC: FrictionlessElastic,
+}
+
 
 BALL_BALL_DEFAULT = FrictionlessElastic()
 
-__all__ = [
-    "FrictionlessElastic",
-]
+
+def get_ball_ball_model(
+    model: Optional[BallBallModel] = None, **kwargs
+) -> BallBallCollisionStrategy:
+    if model is None:
+        return BALL_BALL_DEFAULT
+
+    return _ball_ball_models[model](**kwargs)

--- a/pooltool/physics/resolve/ball_ball/__init__.py
+++ b/pooltool/physics/resolve/ball_ball/__init__.py
@@ -2,6 +2,7 @@ from typing import Dict, Optional, Protocol, Tuple, Type
 
 from pooltool.objects.ball.datatypes import Ball
 from pooltool.physics.resolve.ball_ball.frictionless_elastic import FrictionlessElastic
+from pooltool.physics.resolve.types import ModelArgs
 from pooltool.utils.strenum import StrEnum, auto
 
 
@@ -25,9 +26,9 @@ BALL_BALL_DEFAULT = FrictionlessElastic()
 
 
 def get_ball_ball_model(
-    model: Optional[BallBallModel] = None, **kwargs
+    model: Optional[BallBallModel] = None, params: ModelArgs = {}
 ) -> BallBallCollisionStrategy:
     if model is None:
         return BALL_BALL_DEFAULT
 
-    return _ball_ball_models[model](**kwargs)
+    return _ball_ball_models[model](**params)

--- a/pooltool/physics/resolve/ball_cushion/__init__.py
+++ b/pooltool/physics/resolve/ball_cushion/__init__.py
@@ -9,6 +9,7 @@ from pooltool.physics.resolve.ball_cushion.han_2005 import (
     Han2005Circular,
     Han2005Linear,
 )
+from pooltool.physics.resolve.types import ModelArgs
 from pooltool.utils.strenum import StrEnum, auto
 
 
@@ -48,18 +49,18 @@ BALL_CIRCULAR_CUSHION_DEFAULT = Han2005Circular()
 
 
 def get_ball_lin_cushion_model(
-    model: Optional[BallLCushionModel] = None, **kwargs
+    model: Optional[BallLCushionModel] = None, params: ModelArgs = {}
 ) -> BallLCushionCollisionStrategy:
     if model is None:
         return BALL_LINEAR_CUSHION_DEFAULT
 
-    return _ball_lcushion_models[model](**kwargs)
+    return _ball_lcushion_models[model](**params)
 
 
 def get_ball_circ_cushion_model(
-    model: Optional[BallCCushionModel] = None, **kwargs
+    model: Optional[BallCCushionModel] = None, params: ModelArgs = {}
 ) -> BallCCushionCollisionStrategy:
     if model is None:
         return BALL_CIRCULAR_CUSHION_DEFAULT
 
-    return _ball_ccushion_models[model](**kwargs)
+    return _ball_ccushion_models[model](**params)

--- a/pooltool/physics/resolve/ball_cushion/__init__.py
+++ b/pooltool/physics/resolve/ball_cushion/__init__.py
@@ -1,7 +1,65 @@
+from typing import Dict, Optional, Protocol, Tuple, Type
+
+from pooltool.objects.ball.datatypes import Ball
+from pooltool.objects.table.components import (
+    CircularCushionSegment,
+    LinearCushionSegment,
+)
 from pooltool.physics.resolve.ball_cushion.han_2005 import (
     Han2005Circular,
     Han2005Linear,
 )
+from pooltool.utils.strenum import StrEnum, auto
+
+
+class BallLCushionCollisionStrategy(Protocol):
+    def resolve(
+        self, ball: Ball, cushion: LinearCushionSegment, inplace: bool = False
+    ) -> Tuple[Ball, LinearCushionSegment]:
+        ...
+
+
+class BallCCushionCollisionStrategy(Protocol):
+    def resolve(
+        self, ball: Ball, cushion: CircularCushionSegment, inplace: bool = False
+    ) -> Tuple[Ball, CircularCushionSegment]:
+        ...
+
+
+class BallLCushionModel(StrEnum):
+    HAN_2005 = auto()
+
+
+class BallCCushionModel(StrEnum):
+    HAN_2005 = auto()
+
+
+_ball_lcushion_models: Dict[BallLCushionModel, Type[BallLCushionCollisionStrategy]] = {
+    BallLCushionModel.HAN_2005: Han2005Linear,
+}
+
+_ball_ccushion_models: Dict[BallCCushionModel, Type[BallCCushionCollisionStrategy]] = {
+    BallCCushionModel.HAN_2005: Han2005Circular,
+}
+
 
 BALL_LINEAR_CUSHION_DEFAULT = Han2005Linear()
 BALL_CIRCULAR_CUSHION_DEFAULT = Han2005Circular()
+
+
+def get_ball_lin_cushion_model(
+    model: Optional[BallLCushionModel] = None, **kwargs
+) -> BallLCushionCollisionStrategy:
+    if model is None:
+        return BALL_LINEAR_CUSHION_DEFAULT
+
+    return _ball_lcushion_models[model](**kwargs)
+
+
+def get_ball_circ_cushion_model(
+    model: Optional[BallCCushionModel] = None, **kwargs
+) -> BallCCushionCollisionStrategy:
+    if model is None:
+        return BALL_CIRCULAR_CUSHION_DEFAULT
+
+    return _ball_ccushion_models[model](**kwargs)

--- a/pooltool/physics/resolve/ball_pocket/__init__.py
+++ b/pooltool/physics/resolve/ball_pocket/__init__.py
@@ -5,6 +5,7 @@ import numpy as np
 import pooltool.constants as const
 from pooltool.objects.ball.datatypes import Ball, BallState
 from pooltool.objects.table.components import Pocket
+from pooltool.physics.resolve.types import ModelArgs
 from pooltool.utils.strenum import StrEnum, auto
 
 
@@ -46,10 +47,11 @@ BALL_POCKET_DEFAULT = CanonicalBallPocket()
 
 
 def get_ball_pocket_model(
-    model: Optional[BallPocketModel] = None,
+    model: Optional[BallPocketModel] = None, params: ModelArgs = {}
 ) -> BallPocketStrategy:
     if model is None:
         return BALL_POCKET_DEFAULT
 
+    assert not len(params)
     assert model == BallPocketModel.CANONICAL
     return CanonicalBallPocket()

--- a/pooltool/physics/resolve/ball_pocket/__init__.py
+++ b/pooltool/physics/resolve/ball_pocket/__init__.py
@@ -1,10 +1,18 @@
-from typing import Tuple
+from typing import Optional, Protocol, Tuple
 
 import numpy as np
 
 import pooltool.constants as const
 from pooltool.objects.ball.datatypes import Ball, BallState
 from pooltool.objects.table.components import Pocket
+from pooltool.utils.strenum import StrEnum, auto
+
+
+class BallPocketStrategy(Protocol):
+    def resolve(
+        self, ball: Ball, pocket: Pocket, inplace: bool = False
+    ) -> Tuple[Ball, Pocket]:
+        ...
 
 
 class CanonicalBallPocket:
@@ -30,4 +38,18 @@ class CanonicalBallPocket:
         return ball, pocket
 
 
+class BallPocketModel(StrEnum):
+    CANONICAL = auto()
+
+
 BALL_POCKET_DEFAULT = CanonicalBallPocket()
+
+
+def get_ball_pocket_model(
+    model: Optional[BallPocketModel] = None,
+) -> BallPocketStrategy:
+    if model is None:
+        return BALL_POCKET_DEFAULT
+
+    assert model == BallPocketModel.CANONICAL
+    return CanonicalBallPocket()

--- a/pooltool/physics/resolve/resolver.py
+++ b/pooltool/physics/resolve/resolver.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, Union
 
 import attrs
 
@@ -35,14 +34,9 @@ from pooltool.physics.resolve.transition import (
     BallTransitionStrategy,
     get_transition_model,
 )
+from pooltool.physics.resolve.types import ModelArgs
 from pooltool.serialize import Pathish, conversion
 from pooltool.system.datatypes import System
-
-ArgType = Union[float, int, str, bool]
-ModelArgs = Dict[str, ArgType]
-
-# Leave type-casting to the JSON/YAML serializer
-conversion.register_structure_hook(cl=ArgType, func=lambda d, t: d)
 
 RESOLVER_CONFIG_PATH = pooltool.user_config.PHYSICS_DIR / "resolver.json"
 
@@ -50,17 +44,17 @@ RESOLVER_CONFIG_PATH = pooltool.user_config.PHYSICS_DIR / "resolver.json"
 @attrs.define
 class ResolverConfig:
     ball_ball: BallBallModel
-    ball_ball_kwargs: ModelArgs
+    ball_ball_params: ModelArgs
     ball_linear_cushion: BallLCushionModel
-    ball_linear_cushion_kwargs: ModelArgs
+    ball_linear_cushion_params: ModelArgs
     ball_circular_cushion: BallCCushionModel
-    ball_circular_cushion_kwargs: ModelArgs
+    ball_circular_cushion_params: ModelArgs
     ball_pocket: BallPocketModel
-    ball_pocket_kwargs: ModelArgs
+    ball_pocket_params: ModelArgs
     stick_ball: StickBallModel
-    stick_ball_kwargs: ModelArgs
+    stick_ball_params: ModelArgs
     transition: BallTransitionModel
-    transition_kwargs: ModelArgs
+    transition_params: ModelArgs
 
     def save(self, path: Pathish) -> Path:
         path = Path(path)
@@ -79,17 +73,17 @@ class ResolverConfig:
 
         config = cls(
             ball_ball=BallBallModel.FRICTIONLESS_ELASTIC,
-            ball_ball_kwargs={},
+            ball_ball_params={},
             ball_linear_cushion=BallLCushionModel.HAN_2005,
-            ball_linear_cushion_kwargs={},
+            ball_linear_cushion_params={},
             ball_circular_cushion=BallCCushionModel.HAN_2005,
-            ball_circular_cushion_kwargs={},
+            ball_circular_cushion_params={},
             ball_pocket=BallPocketModel.CANONICAL,
-            ball_pocket_kwargs={},
+            ball_pocket_params={},
             stick_ball=StickBallModel.INSTANTANEOUS_POINT,
-            stick_ball_kwargs={},
+            stick_ball_params={},
             transition=BallTransitionModel.CANONICAL,
-            transition_kwargs={},
+            transition_params={},
         )
 
         config.save(RESOLVER_CONFIG_PATH)
@@ -153,27 +147,27 @@ class Resolver:
     def from_config(cls, config: ResolverConfig) -> Resolver:
         ball_ball = get_ball_ball_model(
             model=config.ball_ball,
-            **config.ball_ball_kwargs,
+            params=config.ball_ball_params,
         )
         ball_linear_cushion = get_ball_lin_cushion_model(
             model=config.ball_linear_cushion,
-            **config.ball_linear_cushion_kwargs,
+            params=config.ball_linear_cushion_params,
         )
         ball_circular_cushion = get_ball_circ_cushion_model(
             model=config.ball_circular_cushion,
-            **config.ball_circular_cushion_kwargs,
+            params=config.ball_circular_cushion_params,
         )
         ball_pocket = get_ball_pocket_model(
             model=config.ball_pocket,
-            **config.ball_pocket_kwargs,
+            params=config.ball_pocket_params,
         )
         stick_ball = get_stick_ball_model(
             model=config.stick_ball,
-            **config.stick_ball_kwargs,
+            params=config.stick_ball_params,
         )
         transition = get_transition_model(
             model=config.transition,
-            **config.transition_kwargs,
+            params=config.transition_params,
         )
         return cls(
             ball_ball,

--- a/pooltool/physics/resolve/resolver.py
+++ b/pooltool/physics/resolve/resolver.py
@@ -1,71 +1,38 @@
 from __future__ import annotations
 
-from typing import Protocol, Tuple
-
 import attrs
 
 from pooltool.events.datatypes import AgentType, Event, EventType
-from pooltool.objects.ball.datatypes import Ball
-from pooltool.objects.cue.datatypes import Cue
-from pooltool.objects.table.components import (
-    CircularCushionSegment,
-    LinearCushionSegment,
-    Pocket,
+from pooltool.physics.resolve.ball_ball import (
+    BallBallCollisionStrategy,
+    get_ball_ball_model,
 )
-from pooltool.physics.resolve.ball_ball import BALL_BALL_DEFAULT
 from pooltool.physics.resolve.ball_cushion import (
-    BALL_CIRCULAR_CUSHION_DEFAULT,
-    BALL_LINEAR_CUSHION_DEFAULT,
+    BallCCushionCollisionStrategy,
+    BallLCushionCollisionStrategy,
+    get_ball_circ_cushion_model,
+    get_ball_lin_cushion_model,
 )
-from pooltool.physics.resolve.ball_pocket import BALL_POCKET_DEFAULT
-from pooltool.physics.resolve.stick_ball import STICK_BALL_DEFAULT
-from pooltool.physics.resolve.transition import TRANSITION_DEFAULT
+from pooltool.physics.resolve.ball_pocket import (
+    BallPocketStrategy,
+    get_ball_pocket_model,
+)
+from pooltool.physics.resolve.stick_ball import (
+    StickBallCollisionStrategy,
+    get_stick_ball_model,
+)
+from pooltool.physics.resolve.transition import (
+    BallTransitionStrategy,
+    get_transition_model,
+)
 from pooltool.system.datatypes import System
-
-
-class BallBallCollisionStrategy(Protocol):
-    def resolve(
-        self, ball1: Ball, ball2: Ball, inplace: bool = False
-    ) -> Tuple[Ball, Ball]:
-        ...
-
-
-class BallTransitionStrategy(Protocol):
-    def resolve(self, ball: Ball, transition: EventType, inplace: bool = False) -> Ball:
-        ...
-
-
-class BallPocketStrategy(Protocol):
-    def resolve(
-        self, ball: Ball, pocket: Pocket, inplace: bool = False
-    ) -> Tuple[Ball, Pocket]:
-        ...
-
-
-class BallLinearCushionCollisionStrategy(Protocol):
-    def resolve(
-        self, ball: Ball, cushion: LinearCushionSegment, inplace: bool = False
-    ) -> Tuple[Ball, LinearCushionSegment]:
-        ...
-
-
-class BallCircularCushionCollisionStrategy(Protocol):
-    def resolve(
-        self, ball: Ball, cushion: CircularCushionSegment, inplace: bool = False
-    ) -> Tuple[Ball, CircularCushionSegment]:
-        ...
-
-
-class StickBallCollisionStrategy(Protocol):
-    def resolve(self, cue: Cue, ball: Ball, inplace: bool = False) -> Tuple[Cue, Ball]:
-        ...
 
 
 @attrs.define
 class Resolver:
     ball_ball: BallBallCollisionStrategy
-    ball_linear_cushion: BallLinearCushionCollisionStrategy
-    ball_circular_cushion: BallCircularCushionCollisionStrategy
+    ball_linear_cushion: BallLCushionCollisionStrategy
+    ball_circular_cushion: BallCCushionCollisionStrategy
     ball_pocket: BallPocketStrategy
     stick_ball: StickBallCollisionStrategy
     transition: BallTransitionStrategy
@@ -113,12 +80,12 @@ class Resolver:
     @classmethod
     def default(cls) -> Resolver:
         return cls(
-            ball_ball=BALL_BALL_DEFAULT,
-            ball_linear_cushion=BALL_LINEAR_CUSHION_DEFAULT,
-            ball_circular_cushion=BALL_CIRCULAR_CUSHION_DEFAULT,
-            ball_pocket=BALL_POCKET_DEFAULT,
-            stick_ball=STICK_BALL_DEFAULT,
-            transition=TRANSITION_DEFAULT,
+            ball_ball=get_ball_ball_model(),
+            ball_linear_cushion=get_ball_lin_cushion_model(),
+            ball_circular_cushion=get_ball_circ_cushion_model(),
+            ball_pocket=get_ball_pocket_model(),
+            stick_ball=get_stick_ball_model(),
+            transition=get_transition_model(),
         )
 
 

--- a/pooltool/physics/resolve/stick_ball/__init__.py
+++ b/pooltool/physics/resolve/stick_ball/__init__.py
@@ -3,6 +3,7 @@ from typing import Dict, Optional, Protocol, Tuple, Type
 from pooltool.objects.ball.datatypes import Ball
 from pooltool.objects.cue.datatypes import Cue
 from pooltool.physics.resolve.stick_ball.instantaneous_point import InstantaneousPoint
+from pooltool.physics.resolve.types import ModelArgs
 from pooltool.utils.strenum import StrEnum, auto
 
 
@@ -23,9 +24,9 @@ STICK_BALL_DEFAULT = InstantaneousPoint()
 
 
 def get_stick_ball_model(
-    model: Optional[StickBallModel] = None, **kwargs
+    model: Optional[StickBallModel] = None, params: ModelArgs = {}
 ) -> StickBallCollisionStrategy:
     if model is None:
         return STICK_BALL_DEFAULT
 
-    return _stick_ball_models[model](**kwargs)
+    return _stick_ball_models[model](**params)

--- a/pooltool/physics/resolve/stick_ball/__init__.py
+++ b/pooltool/physics/resolve/stick_ball/__init__.py
@@ -1,3 +1,31 @@
+from typing import Dict, Optional, Protocol, Tuple, Type
+
+from pooltool.objects.ball.datatypes import Ball
+from pooltool.objects.cue.datatypes import Cue
 from pooltool.physics.resolve.stick_ball.instantaneous_point import InstantaneousPoint
+from pooltool.utils.strenum import StrEnum, auto
+
+
+class StickBallCollisionStrategy(Protocol):
+    def resolve(self, cue: Cue, ball: Ball, inplace: bool = False) -> Tuple[Cue, Ball]:
+        ...
+
+
+class StickBallModel(StrEnum):
+    INSTANTANEOUS_POINT = auto()
+
+
+_stick_ball_models: Dict[StickBallModel, Type[StickBallCollisionStrategy]] = {
+    StickBallModel.INSTANTANEOUS_POINT: InstantaneousPoint,
+}
 
 STICK_BALL_DEFAULT = InstantaneousPoint()
+
+
+def get_stick_ball_model(
+    model: Optional[StickBallModel] = None, **kwargs
+) -> StickBallCollisionStrategy:
+    if model is None:
+        return STICK_BALL_DEFAULT
+
+    return _stick_ball_models[model](**kwargs)

--- a/pooltool/physics/resolve/transition/__init__.py
+++ b/pooltool/physics/resolve/transition/__init__.py
@@ -5,6 +5,7 @@ import numpy as np
 import pooltool.constants as const
 from pooltool.events.datatypes import EventType
 from pooltool.objects.ball.datatypes import Ball
+from pooltool.physics.resolve.types import ModelArgs
 from pooltool.utils.strenum import StrEnum, auto
 
 
@@ -76,9 +77,11 @@ TRANSITION_DEFAULT = CanonicalTransition()
 
 def get_transition_model(
     model: Optional[BallTransitionModel] = None,
+    params: ModelArgs = {},
 ) -> BallTransitionStrategy:
     if model is None:
         return TRANSITION_DEFAULT
 
+    assert not len(params)
     assert model == BallTransitionModel.CANONICAL
     return CanonicalTransition()

--- a/pooltool/physics/resolve/transition/__init__.py
+++ b/pooltool/physics/resolve/transition/__init__.py
@@ -1,10 +1,16 @@
-from typing import Tuple
+from typing import Optional, Protocol, Tuple
 
 import numpy as np
 
 import pooltool.constants as const
 from pooltool.events.datatypes import EventType
 from pooltool.objects.ball.datatypes import Ball
+from pooltool.utils.strenum import StrEnum, auto
+
+
+class BallTransitionStrategy(Protocol):
+    def resolve(self, ball: Ball, transition: EventType, inplace: bool = False) -> Ball:
+        ...
 
 
 class CanonicalTransition:
@@ -61,4 +67,18 @@ def _ball_transition_motion_states(event_type: EventType) -> Tuple[int, int]:
     raise NotImplementedError()
 
 
+class TransitionModel(StrEnum):
+    CANONICAL = auto()
+
+
 TRANSITION_DEFAULT = CanonicalTransition()
+
+
+def get_transition_model(
+    model: Optional[TransitionModel] = None,
+) -> BallTransitionStrategy:
+    if model is None:
+        return TRANSITION_DEFAULT
+
+    assert model == TransitionModel.CANONICAL
+    return CanonicalTransition()

--- a/pooltool/physics/resolve/transition/__init__.py
+++ b/pooltool/physics/resolve/transition/__init__.py
@@ -67,7 +67,7 @@ def _ball_transition_motion_states(event_type: EventType) -> Tuple[int, int]:
     raise NotImplementedError()
 
 
-class TransitionModel(StrEnum):
+class BallTransitionModel(StrEnum):
     CANONICAL = auto()
 
 
@@ -75,10 +75,10 @@ TRANSITION_DEFAULT = CanonicalTransition()
 
 
 def get_transition_model(
-    model: Optional[TransitionModel] = None,
+    model: Optional[BallTransitionModel] = None,
 ) -> BallTransitionStrategy:
     if model is None:
         return TRANSITION_DEFAULT
 
-    assert model == TransitionModel.CANONICAL
+    assert model == BallTransitionModel.CANONICAL
     return CanonicalTransition()

--- a/pooltool/physics/resolve/types.py
+++ b/pooltool/physics/resolve/types.py
@@ -1,0 +1,9 @@
+from typing import Mapping, Union
+
+from pooltool.serialize import conversion
+
+ArgType = Union[float, int, str, bool]
+ModelArgs = Mapping[str, ArgType]
+
+# Leave type-casting to the JSON/YAML serializer
+conversion.register_structure_hook(cl=ArgType, func=lambda d, t: d)

--- a/pooltool/serialize/serializers.py
+++ b/pooltool/serialize/serializers.py
@@ -1,9 +1,11 @@
 import json
 from pathlib import Path
-import yaml
+from typing import Any, Callable, Dict, Union
+
 import msgpack
 import msgpack_numpy as m
-from typing import Union, Any, Dict, Callable
+import yaml
+
 from pooltool.utils.strenum import StrEnum, auto
 
 Pathish = Union[str, Path]
@@ -21,7 +23,7 @@ class SerializeFormat(StrEnum):
 
 def to_json(o: Any, path: Pathish) -> None:
     with open(path, "w") as fp:
-        json.dump(o, fp)
+        json.dump(o, fp, indent=2)
 
 
 def from_json(path: Pathish) -> Any:

--- a/pooltool/user_config.py
+++ b/pooltool/user_config.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+HOME = Path.home()
+
+CONFIG_DIR = HOME / ".config/pooltool"
+CONFIG_DIR.mkdir(parents=True, exist_ok=True)

--- a/pooltool/user_config.py
+++ b/pooltool/user_config.py
@@ -4,3 +4,6 @@ HOME = Path.home()
 
 CONFIG_DIR = HOME / ".config/pooltool"
 CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+
+PHYSICS_DIR = CONFIG_DIR / "physics"
+PHYSICS_DIR.mkdir(exist_ok=True)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ black
 isort
 types-Pillow
 twine
+types-PyYAML


### PR DESCRIPTION
This PR adds the data structures required for a user config.

The user config for resolving physics events is stored in `~/.config/pooltool/physics/resolver.json`. If `~/.config/pooltool/` does not exist, it will be created, along with `resolver.json`, the first time pooltool is ran.

The contents look like this:

```
{
  "ball_ball": "frictionless_elastic",
  "ball_ball_params": {},
  "ball_linear_cushion": "han_2005",
  "ball_linear_cushion_params": {},
  "ball_circular_cushion": "han_2005",
  "ball_circular_cushion_params": {},
  "ball_pocket": "canonical",
  "ball_pocket_params": {},
  "stick_ball": "instantaneous_point",
  "stick_ball_params": {},
  "transition": "canonical",
  "transition_params": {}
}
```

`resolver.json` is a 1:1 serialization of the dataclass `ResolverConfig`:

```python
@attrs.define
class ResolverConfig:
    ball_ball: BallBallModel
    ball_ball_params: ModelArgs
    ball_linear_cushion: BallLCushionModel
    ball_linear_cushion_params: ModelArgs
    ball_circular_cushion: BallCCushionModel
    ball_circular_cushion_params: ModelArgs
    ball_pocket: BallPocketModel
    ball_pocket_params: ModelArgs
    stick_ball: StickBallModel
    stick_ball_params: ModelArgs
    transition: BallTransitionModel
    transition_params: ModelArgs

    def save(self, path: Pathish) -> Path:
        path = Path(path)
        conversion.unstructure_to(self, path)
        return path

    @classmethod
    def load(cls, path: Pathish) -> ResolverConfig:
        return conversion.structure_from(path, cls)

    @classmethod
    def default(cls) -> ResolverConfig:
        """Load ~/.config/pooltool/physics/resolver.json if exists, create otherwise"""
        if RESOLVER_CONFIG_PATH.exists():
            return cls.load(RESOLVER_CONFIG_PATH)

        config = cls(
            ball_ball=BallBallModel.FRICTIONLESS_ELASTIC,
            ball_ball_params={},
            ball_linear_cushion=BallLCushionModel.HAN_2005,
            ball_linear_cushion_params={},
            ball_circular_cushion=BallCCushionModel.HAN_2005,
            ball_circular_cushion_params={},
            ball_pocket=BallPocketModel.CANONICAL,
            ball_pocket_params={},
            stick_ball=StickBallModel.INSTANTANEOUS_POINT,
            stick_ball_params={},
            transition=BallTransitionModel.CANONICAL,
            transition_params={},
        )

        config.save(RESOLVER_CONFIG_PATH)
        return config
```

As you can see, calling `ResolverConfig.default()` will return a `ResolverConfig` object structured from the `resolver.json` payload. When a `ResolverConfig` has been created, it can be used to construct a `Resolver` object via the classmethod `Resolver.from_config`.

With this in place, I think there's nothing left to do but example how different physics models can be constructed and plugged into pooltool.