### PR TITLE
Refinement

### DIFF
--- a/pooltool/objects/table/components.py
+++ b/pooltool/objects/table/components.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import copy
-import enum
 from functools import cached_property
 from typing import Dict, Union
 

--- a/pooltool/physics/resolve/ball_ball/__init__.py
+++ b/pooltool/physics/resolve/ball_ball/__init__.py
@@ -1,16 +1,9 @@
-from typing import Dict, Optional, Protocol, Tuple, Type
+from typing import Dict, Optional, Type
 
-from pooltool.objects.ball.datatypes import Ball
+from pooltool.physics.resolve.ball_ball.core import BallBallCollisionStrategy
 from pooltool.physics.resolve.ball_ball.frictionless_elastic import FrictionlessElastic
 from pooltool.physics.resolve.types import ModelArgs
 from pooltool.utils.strenum import StrEnum, auto
-
-
-class BallBallCollisionStrategy(Protocol):
-    def resolve(
-        self, ball1: Ball, ball2: Ball, inplace: bool = False
-    ) -> Tuple[Ball, Ball]:
-        ...
 
 
 class BallBallModel(StrEnum):
@@ -20,7 +13,6 @@ class BallBallModel(StrEnum):
 _ball_ball_models: Dict[BallBallModel, Type[BallBallCollisionStrategy]] = {
     BallBallModel.FRICTIONLESS_ELASTIC: FrictionlessElastic,
 }
-
 
 BALL_BALL_DEFAULT = FrictionlessElastic()
 

--- a/pooltool/physics/resolve/ball_ball/__init__.py
+++ b/pooltool/physics/resolve/ball_ball/__init__.py
@@ -14,13 +14,11 @@ _ball_ball_models: Dict[BallBallModel, Type[BallBallCollisionStrategy]] = {
     BallBallModel.FRICTIONLESS_ELASTIC: FrictionlessElastic,
 }
 
-BALL_BALL_DEFAULT = FrictionlessElastic()
-
 
 def get_ball_ball_model(
     model: Optional[BallBallModel] = None, params: ModelArgs = {}
 ) -> BallBallCollisionStrategy:
     if model is None:
-        return BALL_BALL_DEFAULT
+        return FrictionlessElastic()
 
     return _ball_ball_models[model](**params)

--- a/pooltool/physics/resolve/ball_ball/core.py
+++ b/pooltool/physics/resolve/ball_ball/core.py
@@ -1,0 +1,58 @@
+from abc import ABC, abstractmethod
+from typing import Protocol, Tuple
+
+import pooltool.constants as const
+import pooltool.math as math
+from pooltool.objects.ball.datatypes import Ball
+
+
+class _BaseStrategy(Protocol):
+    def make_kiss(self, ball1: Ball, ball2: Ball) -> Tuple[Ball, Ball]:
+        ...
+
+    def resolve(
+        self, ball1: Ball, ball2: Ball, inplace: bool = False
+    ) -> Tuple[Ball, Ball]:
+        ...
+
+
+class BallBallCollisionStrategy(_BaseStrategy, Protocol):
+    def solve(self, ball1: Ball, ball2: Ball) -> Tuple[Ball, Ball]:
+        ...
+
+
+class CoreBallBallCollision(ABC):
+    """Operations used by every ball-ball collision resolver"""
+
+    def make_kiss(self, ball1: Ball, ball2: Ball) -> Tuple[Ball, Ball]:
+        """Translate the balls so they are (almost) touching
+
+        This makes a correction such that if the balls are not _exactly_ 2*R apart, they
+        are moved equally along their line of centers such that they are. Then, to avoid
+        downstream float precision round-off errors, a small epsilon of additional
+        distance (constants.EPS_SPACE) is put between them, ensuring the balls are
+        non-intersecting.
+        """
+        r1, r2 = ball1.state.rvw[0], ball2.state.rvw[0]
+        n = math.unit_vector(r2 - r1)
+
+        correction = 2 * ball1.params.R - math.norm3d(r2 - r1) + const.EPS_SPACE
+        ball2.state.rvw[0] += correction / 2 * n
+        ball1.state.rvw[0] -= correction / 2 * n
+
+        return ball1, ball2
+
+    def resolve(
+        self, ball1: Ball, ball2: Ball, inplace: bool = False
+    ) -> Tuple[Ball, Ball]:
+        if not inplace:
+            ball1 = ball1.copy()
+            ball2 = ball2.copy()
+
+        ball1, ball2 = self.make_kiss(ball1, ball2)
+
+        return self.solve(ball1, ball2)
+
+    @abstractmethod
+    def solve(self, ball1: Ball, ball2: Ball) -> Tuple[Ball, Ball]:
+        pass

--- a/pooltool/physics/resolve/ball_ball/frictionless_elastic/__init__.py
+++ b/pooltool/physics/resolve/ball_ball/frictionless_elastic/__init__.py
@@ -8,23 +8,13 @@ from pooltool.objects.ball.datatypes import Ball, BallState
 
 
 def _resolve_ball_ball(rvw1, rvw2, R):
-    """Frictionless, instantaneous, elastic, equal mass collision
-
-    NOTE A correction is made such that if the balls are not 2*R apart, they are moved
-    equally along their line of centers such that they are. To avoid float precision
-    round-off error, a small epsilon of additional distance (constants.EPS_SPACE) is put
-    between them, ensuring the balls are non-intersecting.
-    """
+    """Frictionless, instantaneous, elastic, equal mass collision"""
 
     r1, r2 = rvw1[0], rvw2[0]
     v1, v2 = rvw1[1], rvw2[1]
 
     n = math.unit_vector(r2 - r1)
     t = math.coordinate_rotation(n, np.pi / 2)
-
-    correction = 2 * R - math.norm3d(r2 - r1) + const.EPS_SPACE
-    rvw2[0] += correction / 2 * n
-    rvw1[0] -= correction / 2 * n
 
     v_rel = v1 - v2
     v_mag = math.norm3d(v_rel)
@@ -37,27 +27,40 @@ def _resolve_ball_ball(rvw1, rvw2, R):
     return rvw1, rvw2
 
 
-def resolve_ball_ball(
-    ball1: Ball, ball2: Ball, inplace: bool = False
-) -> Tuple[Ball, Ball]:
-    if not inplace:
-        ball1 = ball1.copy()
-        ball2 = ball2.copy()
-
-    rvw1, rvw2 = _resolve_ball_ball(
-        ball1.state.rvw.copy(),
-        ball2.state.rvw.copy(),
-        ball1.params.R,
-    )
-
-    ball1.state = BallState(rvw1, const.sliding)
-    ball2.state = BallState(rvw2, const.sliding)
-
-    return ball1, ball2
-
-
 class FrictionlessElastic:
     def resolve(
         self, ball1: Ball, ball2: Ball, inplace: bool = False
     ) -> Tuple[Ball, Ball]:
-        return resolve_ball_ball(ball1, ball2, inplace=inplace)
+        if not inplace:
+            ball1 = ball1.copy()
+            ball2 = ball2.copy()
+
+        ball1, ball2 = self.make_kiss(ball1, ball2)
+
+        rvw1, rvw2 = _resolve_ball_ball(
+            ball1.state.rvw.copy(),
+            ball2.state.rvw.copy(),
+            ball1.params.R,
+        )
+
+        ball1.state = BallState(rvw1, const.sliding)
+        ball2.state = BallState(rvw2, const.sliding)
+
+        return ball1, ball2
+
+    def make_kiss(self, ball1: Ball, ball2: Ball) -> Tuple[Ball, Ball]:
+        """Translate the balls so they are (almost) touching
+
+        This makes a correction such that if the balls are not 2*R apart, they are moved
+        equally along their line of centers such that they are. To avoid float precision
+        round-off error, a small epsilon of additional distance (constants.EPS_SPACE) is
+        put between them, ensuring the balls are non-intersecting.
+        """
+        r1, r2 = ball1.state.rvw[0], ball2.state.rvw[0]
+        n = math.unit_vector(r2 - r1)
+
+        correction = 2 * ball1.params.R - math.norm3d(r2 - r1) + const.EPS_SPACE
+        ball2.state.rvw[0] += correction / 2 * n
+        ball1.state.rvw[0] -= correction / 2 * n
+
+        return ball1, ball2

--- a/pooltool/physics/resolve/ball_cushion/__init__.py
+++ b/pooltool/physics/resolve/ball_cushion/__init__.py
@@ -28,15 +28,12 @@ _ball_ccushion_models: Dict[BallCCushionModel, Type[BallCCushionCollisionStrateg
     BallCCushionModel.HAN_2005: Han2005Circular,
 }
 
-BALL_LINEAR_CUSHION_DEFAULT = Han2005Linear()
-BALL_CIRCULAR_CUSHION_DEFAULT = Han2005Circular()
-
 
 def get_ball_lin_cushion_model(
     model: Optional[BallLCushionModel] = None, params: ModelArgs = {}
 ) -> BallLCushionCollisionStrategy:
     if model is None:
-        return BALL_LINEAR_CUSHION_DEFAULT
+        return Han2005Linear()
 
     return _ball_lcushion_models[model](**params)
 
@@ -45,6 +42,6 @@ def get_ball_circ_cushion_model(
     model: Optional[BallCCushionModel] = None, params: ModelArgs = {}
 ) -> BallCCushionCollisionStrategy:
     if model is None:
-        return BALL_CIRCULAR_CUSHION_DEFAULT
+        return Han2005Circular()
 
     return _ball_ccushion_models[model](**params)

--- a/pooltool/physics/resolve/ball_cushion/__init__.py
+++ b/pooltool/physics/resolve/ball_cushion/__init__.py
@@ -1,9 +1,8 @@
-from typing import Dict, Optional, Protocol, Tuple, Type
+from typing import Dict, Optional, Type
 
-from pooltool.objects.ball.datatypes import Ball
-from pooltool.objects.table.components import (
-    CircularCushionSegment,
-    LinearCushionSegment,
+from pooltool.physics.resolve.ball_cushion.core import (
+    BallCCushionCollisionStrategy,
+    BallLCushionCollisionStrategy,
 )
 from pooltool.physics.resolve.ball_cushion.han_2005 import (
     Han2005Circular,
@@ -11,20 +10,6 @@ from pooltool.physics.resolve.ball_cushion.han_2005 import (
 )
 from pooltool.physics.resolve.types import ModelArgs
 from pooltool.utils.strenum import StrEnum, auto
-
-
-class BallLCushionCollisionStrategy(Protocol):
-    def resolve(
-        self, ball: Ball, cushion: LinearCushionSegment, inplace: bool = False
-    ) -> Tuple[Ball, LinearCushionSegment]:
-        ...
-
-
-class BallCCushionCollisionStrategy(Protocol):
-    def resolve(
-        self, ball: Ball, cushion: CircularCushionSegment, inplace: bool = False
-    ) -> Tuple[Ball, CircularCushionSegment]:
-        ...
 
 
 class BallLCushionModel(StrEnum):
@@ -42,7 +27,6 @@ _ball_lcushion_models: Dict[BallLCushionModel, Type[BallLCushionCollisionStrateg
 _ball_ccushion_models: Dict[BallCCushionModel, Type[BallCCushionCollisionStrategy]] = {
     BallCCushionModel.HAN_2005: Han2005Circular,
 }
-
 
 BALL_LINEAR_CUSHION_DEFAULT = Han2005Linear()
 BALL_CIRCULAR_CUSHION_DEFAULT = Han2005Circular()

--- a/pooltool/physics/resolve/ball_cushion/core.py
+++ b/pooltool/physics/resolve/ball_cushion/core.py
@@ -1,0 +1,137 @@
+from abc import ABC, abstractmethod
+from typing import Protocol, Tuple
+
+import numpy as np
+
+import pooltool.constants as const
+import pooltool.math as math
+from pooltool.objects.ball.datatypes import Ball
+from pooltool.objects.table.components import (
+    CircularCushionSegment,
+    LinearCushionSegment,
+)
+
+
+class _BaseLinearStrategy(Protocol):
+    def make_kiss(self, ball: Ball, cushion: LinearCushionSegment) -> Ball:
+        ...
+
+    def resolve(
+        self, ball: Ball, cushion: LinearCushionSegment, inplace: bool = False
+    ) -> Tuple[Ball, LinearCushionSegment]:
+        ...
+
+
+class _BaseCircularStrategy(Protocol):
+    def make_kiss(self, ball: Ball, cushion: CircularCushionSegment) -> Ball:
+        ...
+
+    def resolve(
+        self, ball: Ball, cushion: CircularCushionSegment, inplace: bool = False
+    ) -> Tuple[Ball, CircularCushionSegment]:
+        ...
+
+
+class BallLCushionCollisionStrategy(_BaseLinearStrategy, Protocol):
+    def solve(
+        self, ball: Ball, cushion: LinearCushionSegment
+    ) -> Tuple[Ball, LinearCushionSegment]:
+        ...
+
+
+class BallCCushionCollisionStrategy(_BaseCircularStrategy, Protocol):
+    def solve(
+        self, ball: Ball, cushion: CircularCushionSegment
+    ) -> Tuple[Ball, CircularCushionSegment]:
+        ...
+
+
+class CoreBallLCushionCollision(ABC):
+    """Operations used by every ball-linear cushion collision resolver"""
+
+    def make_kiss(self, ball: Ball, cushion: LinearCushionSegment) -> Ball:
+        """Translate the ball so it (almost) touches the linear cushion segment
+
+        This makes a correction such that if the ball is not a distance R from the
+        cushion, the ball is moved along the normal such that it is. To avoid downstream
+        float precision round-off error, a small epsilon of additional distance
+        (constants.EPS_SPACE) is put between them, ensuring the cushion and ball are
+        separated post-resolution.
+        """
+        normal = cushion.get_normal(ball.state.rvw)
+
+        # orient the normal so it points away from playing surface
+        normal = normal if np.dot(normal, ball.state.rvw[1]) > 0 else -normal
+
+        # Calculate the point on cushion line where contact should be made, then set the
+        # z-component to match the ball's height
+        c = math.point_on_line_closest_to_point(
+            cushion.p1, cushion.p2, ball.state.rvw[0]
+        )
+        c[2] = ball.state.rvw[0, 2]
+
+        # Move the ball to exactly meet the cushion
+        correction = (
+            ball.params.R - math.norm3d(ball.state.rvw[0] - c) + const.EPS_SPACE
+        )
+        ball.state.rvw[0] -= correction * normal
+
+        return ball
+
+    def resolve(
+        self, ball: Ball, cushion: LinearCushionSegment, inplace: bool = False
+    ) -> Tuple[Ball, LinearCushionSegment]:
+        if not inplace:
+            ball = ball.copy()
+            cushion = cushion.copy()
+
+        ball = self.make_kiss(ball, cushion)
+
+        return self.solve(ball, cushion)
+
+    @abstractmethod
+    def solve(
+        self, ball: Ball, cushion: LinearCushionSegment
+    ) -> Tuple[Ball, LinearCushionSegment]:
+        pass
+
+
+class CoreBallCCushionCollision(ABC):
+    """Operations used by every ball-linear cushion collision resolver"""
+
+    def make_kiss(self, ball: Ball, cushion: CircularCushionSegment) -> Ball:
+        """Translate the ball so it (almost) touches the circular cushion segment
+
+        This makes a correction such that if the ball is not a distance R from the
+        cushion, the ball is moved along the normal such that it is. To avoid downstream
+        float precision round-off error, a small epsilon of additional distance
+        (constants.EPS_SPACE) is put between them, ensuring the cushion and ball are
+        separated post-resolution.
+        """
+        normal = cushion.get_normal(ball.state.rvw)
+
+        # orient the normal so it points away from playing surface
+        normal = normal if np.dot(normal, ball.state.rvw[1]) > 0 else -normal
+
+        c = np.array([cushion.center[0], cushion.center[1], ball.state.rvw[0, 2]])
+        correction = (
+            ball.params.R
+            + cushion.radius
+            - math.norm3d(ball.state.rvw[0] - c)
+            - const.EPS_SPACE
+        )
+
+        ball.state.rvw[0] += correction * normal
+
+        return ball
+
+    def resolve(
+        self, ball: Ball, cushion: CircularCushionSegment, inplace: bool = False
+    ) -> Tuple[Ball, CircularCushionSegment]:
+        if not inplace:
+            ball = ball.copy()
+            cushion = cushion.copy()
+
+        ball = self.make_kiss(ball, cushion)
+
+        return self.solve(ball, cushion)  # type: ignore

--- a/pooltool/physics/resolve/ball_cushion/han_2005/__init__.py
+++ b/pooltool/physics/resolve/ball_cushion/han_2005/__init__.py
@@ -1,7 +1,5 @@
 from pooltool.physics.resolve.ball_cushion.han_2005.model import (
     Han2005Circular,
     Han2005Linear,
-    base_han2005,
-    circular_han2005,
-    linear_han2005,
+    han2005,
 )

--- a/pooltool/physics/resolve/ball_cushion/han_2005/model.py
+++ b/pooltool/physics/resolve/ball_cushion/han_2005/model.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Tuple, TypeVar
 
 import numpy as np
 
@@ -88,39 +88,34 @@ def han2005(rvw, normal, R, m, h, e_c, f_c):
     return rvw
 
 
+Cushion = TypeVar("Cushion", LinearCushionSegment, CircularCushionSegment)
+
+
+def _solve(ball: Ball, cushion: Cushion) -> Tuple[Ball, Cushion]:
+    rvw = han2005(
+        rvw=ball.state.rvw,
+        normal=cushion.get_normal(ball.state.rvw),
+        R=ball.params.R,
+        m=ball.params.m,
+        h=cushion.height,
+        e_c=ball.params.e_c,
+        f_c=ball.params.f_c,
+    )
+
+    ball.state = BallState(rvw, const.sliding)
+
+    return ball, cushion
+
+
 class Han2005Linear(CoreBallLCushionCollision):
     def solve(
         self, ball: Ball, cushion: LinearCushionSegment
     ) -> Tuple[Ball, LinearCushionSegment]:
-        rvw = han2005(
-            rvw=ball.state.rvw,
-            normal=cushion.get_normal(ball.state.rvw),
-            R=ball.params.R,
-            m=ball.params.m,
-            h=cushion.height,
-            e_c=ball.params.e_c,
-            f_c=ball.params.f_c,
-        )
-
-        ball.state = BallState(rvw, const.sliding)
-
-        return ball, cushion
+        return _solve(ball, cushion)
 
 
 class Han2005Circular(CoreBallCCushionCollision):
     def solve(
         self, ball: Ball, cushion: CircularCushionSegment
     ) -> Tuple[Ball, CircularCushionSegment]:
-        rvw = han2005(
-            rvw=ball.state.rvw,
-            normal=cushion.get_normal(ball.state.rvw),
-            R=ball.params.R,
-            m=ball.params.m,
-            h=cushion.height,
-            e_c=ball.params.e_c,
-            f_c=ball.params.f_c,
-        )
-
-        ball.state = BallState(rvw, const.sliding)
-
-        return ball, cushion
+        return _solve(ball, cushion)

--- a/pooltool/physics/resolve/ball_cushion/han_2005/model.py
+++ b/pooltool/physics/resolve/ball_cushion/han_2005/model.py
@@ -9,70 +9,20 @@ from pooltool.objects.table.components import (
     CircularCushionSegment,
     LinearCushionSegment,
 )
+from pooltool.physics.resolve.ball_cushion.core import (
+    CoreBallCCushionCollision,
+    CoreBallLCushionCollision,
+)
 from pooltool.physics.resolve.ball_cushion.han_2005.properties import (
     get_ball_cushion_friction,
     get_ball_cushion_restitution,
 )
 
 
-class Han2005Linear:
-    def resolve(
-        self, ball: Ball, cushion: LinearCushionSegment, inplace: bool = False
-    ) -> Tuple[Ball, LinearCushionSegment]:
-        if not inplace:
-            ball = ball.copy()
-            cushion = cushion.copy()
-
-        rvw = ball.state.rvw
-        normal = cushion.get_normal(rvw)
-
-        rvw = linear_han2005(
-            rvw=rvw,
-            normal=normal,
-            p1=cushion.p1,
-            p2=cushion.p2,
-            R=ball.params.R,
-            m=ball.params.m,
-            h=cushion.height,
-            e_c=ball.params.e_c,
-            f_c=ball.params.f_c,
-        )
-
-        ball.state = BallState(rvw, const.sliding)
-
-        return ball, cushion
-
-
-class Han2005Circular:
-    def resolve(
-        self, ball: Ball, cushion: CircularCushionSegment, inplace: bool = False
-    ) -> Tuple[Ball, CircularCushionSegment]:
-        if not inplace:
-            ball = ball.copy()
-            cushion = cushion.copy()
-
-        rvw = ball.state.rvw
-        normal = cushion.get_normal(rvw)
-
-        rvw = circular_han2005(
-            rvw=rvw,
-            normal=normal,
-            center=cushion.center,
-            radius=cushion.radius,
-            R=ball.params.R,
-            m=ball.params.m,
-            h=cushion.height,
-            e_c=ball.params.e_c,
-            f_c=ball.params.f_c,
-        )
-
-        ball.state = BallState(rvw, const.sliding)
-
-        return ball, cushion
-
-
-def base_han2005(rvw, normal, R, m, h, e_c, f_c):
+def han2005(rvw, normal, R, m, h, e_c, f_c):
     """Inhwan Han (2005) 'Dynamics in Carom and Three Cushion Billiards'"""
+    # orient the normal so it points away from playing surface
+    normal = normal if np.dot(normal, rvw[1]) > 0 else -normal
 
     # Change from the table frame to the cushion frame. The cushion frame is defined by
     # the normal vector is parallel with <1,0,0>.
@@ -138,49 +88,39 @@ def base_han2005(rvw, normal, R, m, h, e_c, f_c):
     return rvw
 
 
-def linear_han2005(rvw, normal, p1, p2, R, m, h, e_c, f_c):
-    """Resolve the ball linear cushion collision
+class Han2005Linear(CoreBallLCushionCollision):
+    def solve(
+        self, ball: Ball, cushion: LinearCushionSegment
+    ) -> Tuple[Ball, LinearCushionSegment]:
+        rvw = han2005(
+            rvw=ball.state.rvw,
+            normal=cushion.get_normal(ball.state.rvw),
+            R=ball.params.R,
+            m=ball.params.m,
+            h=cushion.height,
+            e_c=ball.params.e_c,
+            f_c=ball.params.f_c,
+        )
 
-    NOTE A correction is made such that if the ball is not a distance R from the
-    cushion, the ball is moved along the normal such that it is. To avoid float
-    precision round-off error, a small epsilon of additional distance
-    (constants.EPS_SPACE) is put between them, ensuring the cushion and ball are
-    separated post-resolution.
-    """
-    # orient the normal so it points away from playing surface
-    normal = normal if np.dot(normal, rvw[1]) > 0 else -normal
+        ball.state = BallState(rvw, const.sliding)
 
-    rvw = base_han2005(rvw, normal, R, m, h, e_c, f_c)
-
-    # Calculate the point on cushion line where contact should be made, then set the
-    # z-component to match the ball's height
-    c = math.point_on_line_closest_to_point(p1, p2, rvw[0])
-    c[2] = rvw[0, 2]
-
-    # Move the ball to exactly meet the cushion
-    correction = R - math.norm3d(rvw[0] - c) + const.EPS_SPACE
-    rvw[0] -= correction * normal
-
-    return rvw
+        return ball, cushion
 
 
-def circular_han2005(rvw, normal, center, radius, R, m, h, e_c, f_c):
-    """Resolve the ball circular cushion collision
+class Han2005Circular(CoreBallCCushionCollision):
+    def solve(
+        self, ball: Ball, cushion: CircularCushionSegment
+    ) -> Tuple[Ball, CircularCushionSegment]:
+        rvw = han2005(
+            rvw=ball.state.rvw,
+            normal=cushion.get_normal(ball.state.rvw),
+            R=ball.params.R,
+            m=ball.params.m,
+            h=cushion.height,
+            e_c=ball.params.e_c,
+            f_c=ball.params.f_c,
+        )
 
-    NOTE A correction is made such that if the ball is not a distance R from the
-    cushion, the ball is moved along the normal such that it is. To avoid float
-    precision round-off error, a small epsilon of additional distance
-    (constants.EPS_SPACE) is put between them, ensuring the cushion and ball are
-    separated post-resolution.
-    """
-    # orient the normal so it points away from playing surface
-    normal = normal if np.dot(normal, rvw[1]) > 0 else -normal
+        ball.state = BallState(rvw, const.sliding)
 
-    rvw = base_han2005(rvw, normal, R, m, h, e_c, f_c)
-
-    c = np.array([center[0], center[1], rvw[0, 2]])
-    correction = R + radius - math.norm3d(rvw[0] - c) - const.EPS_SPACE
-
-    rvw[0] += correction * normal
-
-    return rvw
+        return ball, cushion

--- a/pooltool/physics/resolve/ball_pocket/__init__.py
+++ b/pooltool/physics/resolve/ball_pocket/__init__.py
@@ -4,7 +4,7 @@ NOTE: If this module is ever extended to support multiple treatments for ball po
 collisions, expand this file into a file structure modelled after ../ball_ball or
 ../ball_cushion
 """
-from typing import Optional, Protocol, Tuple
+from typing import Dict, Optional, Protocol, Tuple, Type
 
 import numpy as np
 
@@ -49,15 +49,15 @@ class BallPocketModel(StrEnum):
     CANONICAL = auto()
 
 
-BALL_POCKET_DEFAULT = CanonicalBallPocket()
+_ball_pocket_models: Dict[BallPocketModel, Type[BallPocketStrategy]] = {
+    BallPocketModel.CANONICAL: CanonicalBallPocket,
+}
 
 
 def get_ball_pocket_model(
     model: Optional[BallPocketModel] = None, params: ModelArgs = {}
 ) -> BallPocketStrategy:
     if model is None:
-        return BALL_POCKET_DEFAULT
+        return CanonicalBallPocket()
 
-    assert not len(params)
-    assert model == BallPocketModel.CANONICAL
-    return CanonicalBallPocket()
+    return _ball_pocket_models[model](**params)

--- a/pooltool/physics/resolve/ball_pocket/__init__.py
+++ b/pooltool/physics/resolve/ball_pocket/__init__.py
@@ -1,3 +1,9 @@
+"""Defining and handling ball pocket collisions
+
+NOTE: If this module is ever extended to support multiple treatments for ball pocket
+collisions, expand this file into a file structure modelled after ../ball_ball or
+../ball_cushion
+"""
 from typing import Optional, Protocol, Tuple
 
 import numpy as np

--- a/pooltool/physics/resolve/stick_ball/__init__.py
+++ b/pooltool/physics/resolve/stick_ball/__init__.py
@@ -1,15 +1,9 @@
-from typing import Dict, Optional, Protocol, Tuple, Type
+from typing import Dict, Optional, Type
 
-from pooltool.objects.ball.datatypes import Ball
-from pooltool.objects.cue.datatypes import Cue
+from pooltool.physics.resolve.stick_ball.core import StickBallCollisionStrategy
 from pooltool.physics.resolve.stick_ball.instantaneous_point import InstantaneousPoint
 from pooltool.physics.resolve.types import ModelArgs
 from pooltool.utils.strenum import StrEnum, auto
-
-
-class StickBallCollisionStrategy(Protocol):
-    def resolve(self, cue: Cue, ball: Ball, inplace: bool = False) -> Tuple[Cue, Ball]:
-        ...
 
 
 class StickBallModel(StrEnum):

--- a/pooltool/physics/resolve/stick_ball/__init__.py
+++ b/pooltool/physics/resolve/stick_ball/__init__.py
@@ -14,13 +14,11 @@ _stick_ball_models: Dict[StickBallModel, Type[StickBallCollisionStrategy]] = {
     StickBallModel.INSTANTANEOUS_POINT: InstantaneousPoint,
 }
 
-STICK_BALL_DEFAULT = InstantaneousPoint()
-
 
 def get_stick_ball_model(
     model: Optional[StickBallModel] = None, params: ModelArgs = {}
 ) -> StickBallCollisionStrategy:
     if model is None:
-        return STICK_BALL_DEFAULT
+        return InstantaneousPoint()
 
     return _stick_ball_models[model](**params)

--- a/pooltool/physics/resolve/stick_ball/core.py
+++ b/pooltool/physics/resolve/stick_ball/core.py
@@ -1,0 +1,30 @@
+from abc import ABC, abstractmethod
+from typing import Protocol, Tuple
+
+from pooltool.objects.ball.datatypes import Ball
+from pooltool.objects.cue.datatypes import Cue
+
+
+class _BaseStrategy(Protocol):
+    def resolve(self, cue: Cue, ball: Ball, inplace: bool = False) -> Tuple[Cue, Ball]:
+        ...
+
+
+class StickBallCollisionStrategy(_BaseStrategy, Protocol):
+    def solve(self, cue: Cue, ball: Ball) -> Tuple[Cue, Ball]:
+        ...
+
+
+class CoreStickBallCollision(ABC):
+    """Operations used by every stick-ball collision resolver"""
+
+    def resolve(self, cue: Cue, ball: Ball, inplace: bool = False) -> Tuple[Cue, Ball]:
+        if not inplace:
+            cue = cue.copy()
+            ball = ball.copy()
+
+        return self.solve(cue, ball)
+
+    @abstractmethod
+    def solve(self, cue: Cue, ball: Ball) -> Tuple[Cue, Ball]:
+        pass

--- a/pooltool/physics/resolve/stick_ball/instantaneous_point/__init__.py
+++ b/pooltool/physics/resolve/stick_ball/instantaneous_point/__init__.py
@@ -6,6 +6,7 @@ import pooltool.constants as const
 import pooltool.math as math
 from pooltool.objects.ball.datatypes import Ball, BallState
 from pooltool.objects.cue.datatypes import Cue
+from pooltool.physics.resolve.stick_ball.core import CoreStickBallCollision
 
 
 def cue_strike(m, M, R, V0, phi, theta, a, b):
@@ -102,12 +103,8 @@ def cue_strike(m, M, R, V0, phi, theta, a, b):
     return v_T, w_T
 
 
-class InstantaneousPoint:
-    def resolve(self, cue: Cue, ball: Ball, inplace: bool = False) -> Tuple[Cue, Ball]:
-        if not inplace:
-            cue = cue.copy()
-            ball = ball.copy()
-
+class InstantaneousPoint(CoreStickBallCollision):
+    def solve(self, cue: Cue, ball: Ball) -> Tuple[Cue, Ball]:
         v, w = cue_strike(
             ball.params.m,
             cue.specs.M,

--- a/pooltool/physics/resolve/transition/__init__.py
+++ b/pooltool/physics/resolve/transition/__init__.py
@@ -1,3 +1,9 @@
+"""Defining and handling ball state transitions
+
+NOTE: If this module is ever extended to support multiple treatments for ball
+transitions, expand this file into a file structure modelled after ../ball_ball or
+../ball_cushion
+"""
 from typing import Optional, Protocol, Tuple
 
 import numpy as np

--- a/pooltool/physics/resolve/transition/__init__.py
+++ b/pooltool/physics/resolve/transition/__init__.py
@@ -4,7 +4,7 @@ NOTE: If this module is ever extended to support multiple treatments for ball
 transitions, expand this file into a file structure modelled after ../ball_ball or
 ../ball_cushion
 """
-from typing import Optional, Protocol, Tuple
+from typing import Dict, Optional, Protocol, Tuple, Type
 
 import numpy as np
 
@@ -78,7 +78,9 @@ class BallTransitionModel(StrEnum):
     CANONICAL = auto()
 
 
-TRANSITION_DEFAULT = CanonicalTransition()
+_ball_transition_models: Dict[BallTransitionModel, Type[BallTransitionStrategy]] = {
+    BallTransitionModel.CANONICAL: CanonicalTransition,
+}
 
 
 def get_transition_model(
@@ -86,8 +88,6 @@ def get_transition_model(
     params: ModelArgs = {},
 ) -> BallTransitionStrategy:
     if model is None:
-        return TRANSITION_DEFAULT
+        return CanonicalTransition()
 
-    assert not len(params)
-    assert model == BallTransitionModel.CANONICAL
-    return CanonicalTransition()
+    return _ball_transition_models[model](**params)


### PR DESCRIPTION
I noticed that there was a lot of boiler plate code related to `inplace` arguments as well as operations for ball-cushion and ball-ball collisions that were packaged in the default resolvers, but in fact are general operations that should be applied to _all_ such event resolvers. To remedy this, I've changed things by complicating the collision strategy protocols, and offering a base class that implements logic that should be re-used for each collision resolver.