### PR TITLE
Event caching

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -851,6 +851,22 @@ files = [
 ]
 
 [[package]]
+name = "ipdb"
+version = "0.13.13"
+description = "IPython-enabled pdb"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "ipdb-0.13.13-py3-none-any.whl", hash = "sha256:45529994741c4ab6d2388bfa5d7b725c2cf7fe9deffabdb8a6113aa5ed449ed4"},
+    {file = "ipdb-0.13.13.tar.gz", hash = "sha256:e3ac6018ef05126d442af680aad863006ec19d02290561ac88b8b1c0b0cfc726"},
+]
+
+[package.dependencies]
+decorator = {version = "*", markers = "python_version > \"3.6\""}
+ipython = {version = ">=7.31.1", markers = "python_version > \"3.6\""}
+tomli = {version = "*", markers = "python_version > \"3.6\" and python_version < \"3.11\""}
+
+[[package]]
 name = "ipython"
 version = "8.18.1"
 description = "IPython: Productive Interactive Computing"
@@ -2708,4 +2724,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "338ef1e8dc6ee8b9787d470f6c7d3404ca85f898b1bd3c6429d19a4d3afce297"
+content-hash = "04a6d5859d7eb66caf0b2099295895f644f458f39840d25fb97c1b3e77ad44a4"

--- a/pooltool/events/datatypes.py
+++ b/pooltool/events/datatypes.py
@@ -58,22 +58,22 @@ class EventType(strenum.StrEnum):
 
     def is_collision(self) -> bool:
         """Returns whether the member is a collision"""
-        return self in (
+        return self in {
             EventType.BALL_BALL,
             EventType.BALL_CIRCULAR_CUSHION,
             EventType.BALL_LINEAR_CUSHION,
             EventType.BALL_POCKET,
             EventType.STICK_BALL,
-        )
+        }
 
     def is_transition(self) -> bool:
         """Returns whether the member is a transition"""
-        return self in (
+        return self in {
             EventType.SPINNING_STATIONARY,
             EventType.ROLLING_STATIONARY,
             EventType.ROLLING_SPINNING,
             EventType.SLIDING_ROLLING,
-        )
+        }
 
 
 Object = Union[

--- a/pooltool/events/utils.py
+++ b/pooltool/events/utils.py
@@ -1,0 +1,15 @@
+from typing import Dict, Set
+
+from pooltool.events.datatypes import EventType
+
+event_type_to_ball_indices: Dict[EventType, Set[int]] = {
+    EventType.BALL_BALL: {0, 1},
+    EventType.BALL_LINEAR_CUSHION: {0},
+    EventType.BALL_CIRCULAR_CUSHION: {0},
+    EventType.BALL_POCKET: {0},
+    EventType.STICK_BALL: {1},
+    EventType.SPINNING_STATIONARY: {0},
+    EventType.ROLLING_STATIONARY: {0},
+    EventType.ROLLING_SPINNING: {0},
+    EventType.SLIDING_ROLLING: {0},
+}

--- a/pooltool/evolution/event_based/cache.py
+++ b/pooltool/evolution/event_based/cache.py
@@ -89,11 +89,7 @@ class CollisionCache:
 
     @property
     def size(self) -> int:
-        count = 0
-        for cache in self.times.values():
-            count += len(cache)
-
-        return count
+        return sum(len(cache) for cache in self.times.values())
 
     def _get_invalid_ball_ids(self, event: Event) -> Set[str]:
         invalid_ball_ids = set()
@@ -137,3 +133,7 @@ class CollisionCache:
 
             for key in keys_to_delete:
                 del event_times[key]
+
+    @classmethod
+    def create(cls) -> CollisionCache:
+        return cls()

--- a/pooltool/evolution/event_based/cache.py
+++ b/pooltool/evolution/event_based/cache.py
@@ -1,0 +1,139 @@
+#! /usr/bin/env python
+
+from __future__ import annotations
+
+from typing import Dict, Set, Tuple
+
+import attrs
+import numpy as np
+
+import pooltool.constants as const
+import pooltool.ptmath as ptmath
+from pooltool.events import (
+    AgentType,
+    Event,
+    EventType,
+    null_event,
+    rolling_spinning_transition,
+    rolling_stationary_transition,
+    sliding_rolling_transition,
+    spinning_stationary_transition,
+)
+from pooltool.objects.ball.datatypes import Ball
+from pooltool.system.datatypes import System
+
+
+def _null() -> Dict[str, Event]:
+    return {"null": null_event(time=np.inf)}
+
+
+@attrs.define
+class TransitionCache:
+    transitions: Dict[str, Event] = attrs.field(factory=_null)
+
+    def get_next(self) -> Event:
+        return min(
+            (trans for trans in self.transitions.values()), key=lambda event: event.time
+        )
+
+    def update(self, event: Event) -> None:
+        """Update transition cache for all balls in Event"""
+        for agent in event.agents:
+            if agent.agent_type == AgentType.BALL:
+                assert isinstance(ball := agent.final, Ball)
+                self.transitions[agent.id] = _next_transition(ball)
+
+    @classmethod
+    def create(cls, shot: System) -> TransitionCache:
+        return cls(
+            {ball_id: _next_transition(ball) for ball_id, ball in shot.balls.items()}
+        )
+
+
+def _next_transition(ball: Ball) -> Event:
+    if ball.state.s == const.stationary or ball.state.s == const.pocketed:
+        return null_event(time=np.inf)
+
+    elif ball.state.s == const.spinning:
+        dtau_E = ptmath.get_spin_time(
+            ball.state.rvw, ball.params.R, ball.params.u_sp, ball.params.g
+        )
+        return spinning_stationary_transition(ball, ball.state.t + dtau_E)
+
+    elif ball.state.s == const.rolling:
+        dtau_E_spin = ptmath.get_spin_time(
+            ball.state.rvw, ball.params.R, ball.params.u_sp, ball.params.g
+        )
+        dtau_E_roll = ptmath.get_roll_time(
+            ball.state.rvw, ball.params.u_r, ball.params.g
+        )
+
+        if dtau_E_spin > dtau_E_roll:
+            return rolling_spinning_transition(ball, ball.state.t + dtau_E_roll)
+        else:
+            return rolling_stationary_transition(ball, ball.state.t + dtau_E_roll)
+
+    elif ball.state.s == const.sliding:
+        dtau_E = ptmath.get_slide_time(
+            ball.state.rvw, ball.params.R, ball.params.u_s, ball.params.g
+        )
+        return sliding_rolling_transition(ball, ball.state.t + dtau_E)
+
+    else:
+        raise NotImplementedError(f"Unknown '{ball.state.s=}'")
+
+
+@attrs.define
+class CollisionCache:
+    times: Dict[EventType, Dict[Tuple[str, str], float]] = attrs.field(factory=dict)
+
+    @property
+    def size(self) -> int:
+        count = 0
+        for cache in self.times.values():
+            count += len(cache)
+
+        return count
+
+    def _get_invalid_ball_ids(self, event: Event) -> Set[str]:
+        invalid_ball_ids = set()
+
+        if event.event_type == EventType.BALL_BALL:
+            invalid_ball_ids.update(event.ids)
+        elif event.event_type in {
+            EventType.BALL_LINEAR_CUSHION,
+            EventType.BALL_CIRCULAR_CUSHION,
+            EventType.BALL_POCKET,
+        }:
+            invalid_ball_ids.add(event.agents[0].id)
+        elif event.event_type == EventType.STICK_BALL:
+            invalid_ball_ids.add(event.agents[1].id)
+        else:
+            assert event.event_type.is_transition()
+            invalid_ball_ids.add(event.agents[0].id)
+
+        return invalid_ball_ids
+
+    def invalidate(self, event: Event) -> None:
+        invalid_ball_ids = self._get_invalid_ball_ids(event)
+
+        for event_type, event_times in self.times.items():
+            keys_to_delete = []
+
+            for key in event_times:
+                if event_type == EventType.BALL_BALL:
+                    if key[0] in invalid_ball_ids or key[1] in invalid_ball_ids:
+                        keys_to_delete.append(key)
+                elif event_type in {
+                    EventType.BALL_LINEAR_CUSHION,
+                    EventType.BALL_CIRCULAR_CUSHION,
+                    EventType.BALL_POCKET,
+                }:
+                    if key[0] in invalid_ball_ids:
+                        keys_to_delete.append(key)
+                elif event_type == EventType.STICK_BALL:
+                    if key[1] in invalid_ball_ids:
+                        keys_to_delete.append(key)
+
+            for key in keys_to_delete:
+                del event_times[key]

--- a/pooltool/evolution/event_based/cache.py
+++ b/pooltool/evolution/event_based/cache.py
@@ -30,6 +30,21 @@ def _null() -> Dict[str, Event]:
 
 @attrs.define
 class TransitionCache:
+    """A cache for managing and retrieving the next transition events for balls.
+
+    This class maintains a dictionary of transitions, where each key is ball ID, and
+    each value is the next transition associated with that object.
+
+    Attributes:
+        transitions:
+            A dictionary mapping ball IDs to their corresponding next event.
+
+    See Also:
+        - For practical and historical reasons, events are cached differently depending
+          on whether they are collision events or transition events. For collision
+          event caching, see :class:`CollisionCache`.
+    """
+
     transitions: Dict[str, Event] = attrs.field(factory=_null)
 
     def get_next(self) -> Event:
@@ -86,6 +101,34 @@ def _next_transition(ball: Ball) -> Event:
 
 @attrs.define
 class CollisionCache:
+    """A cache for storing and managing collision times between objects.
+
+    This class is used as a cache for possible future collision times. By caching
+    collision times whenever they are calculated, re-calculating them during each step
+    of the shot evolution algorithm can be avoided in many instances.
+
+    It also provides functionality to invalidate cached events based on realized events,
+    ensuring that outdated data does not persist in the cache. For example, if a
+    ball-transition event for ball with ID "6" is passed to :meth:`invalidate`, all
+    cached event times involving ball ID "6" are removed from the cache, since they are
+    no longer valid.
+
+    Attributes:
+        times:
+            A dictionary where each key is an event type, and each value is another
+            dictionary mapping tuples of object IDs to their corresponding collision
+            times.
+
+    Properties:
+        size:
+            The total number of cached events.
+
+    See Also:
+        - For practical and historical reasons, events are cached differently depending
+          on whether they are collision events or transition events. For transition
+          event caching, see :class:`TransitionCache`.
+    """
+
     times: Dict[EventType, Dict[Tuple[str, str], float]] = attrs.field(factory=dict)
 
     @property

--- a/pooltool/evolution/event_based/simulate.py
+++ b/pooltool/evolution/event_based/simulate.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from itertools import combinations
-from typing import List, Optional, Set, Tuple, cast
+from typing import List, Optional, Set, Tuple
 
 import numpy as np
 
@@ -322,20 +322,7 @@ def get_next_ball_ball_collision(
 
     # The cache is now populated and up-to-date
 
-    # Let's be sure of it
-    for ball1, ball2 in combinations(shot.balls.values(), 2):
-        assert (
-            ball1.id,
-            ball2.id,
-        ) in cache, f"{ball1.id}, {ball2.id} not in cache"
-
-    # Let's be sure of it
-    for ball1_id, ball2_id in cache:
-        assert (
-            cache[(ball1_id, ball2_id)] > shot.t
-        ), f"{ball1_id}, {ball2_id} event time in past!"
-
-    ball_pair = min(cache, key=lambda k: cast(float, cache.get(k)))
+    ball_pair = min(cache, key=lambda k: cache[k])
 
     return ball_ball_collision(
         ball1=shot.balls[ball_pair[0]],
@@ -395,7 +382,7 @@ def get_next_ball_circular_cushion_event(
 
     # The cache is now populated and up-to-date
 
-    ball_id, cushion_id = min(cache, key=lambda k: cast(float, cache.get(k)))
+    ball_id, cushion_id = min(cache, key=lambda k: cache[k])
 
     return ball_circular_cushion_collision(
         ball=shot.balls[ball_id],
@@ -445,7 +432,7 @@ def get_next_ball_linear_cushion_collision(
 
             cache[obj_ids] = shot.t + dtau_E
 
-    obj_ids = min(cache, key=lambda k: cast(float, cache.get(k)))
+    obj_ids = min(cache, key=lambda k: cache[k])
 
     return ball_linear_cushion_collision(
         ball=shot.balls[obj_ids[0]],
@@ -505,7 +492,7 @@ def get_next_ball_pocket_collision(
 
     # The cache is now populated and up-to-date
 
-    ball_id, pocket_id = min(cache, key=lambda k: cast(float, cache.get(k)))
+    ball_id, pocket_id = min(cache, key=lambda k: cache[k])
 
     return ball_pocket_collision(
         ball=shot.balls[ball_id],

--- a/pooltool/evolution/event_based/simulate.py
+++ b/pooltool/evolution/event_based/simulate.py
@@ -317,7 +317,7 @@ def get_next_ball_ball_collision(
 
     if len(collision_coeffs):
         roots = solve_quartics(ps=np.array(collision_coeffs), solver=solver)
-        for root, ball_pair in zip(roots, ball_pairs, strict=True):
+        for root, ball_pair in zip(roots, ball_pairs):
             cache[ball_pair] = shot.t + root
 
     # The cache is now populated and up-to-date
@@ -377,7 +377,7 @@ def get_next_ball_circular_cushion_event(
 
     if len(collision_coeffs):
         roots = solve_quartics(ps=np.array(collision_coeffs), solver=solver)
-        for root, ball_cushion_pair in zip(roots, ball_cushion_pairs, strict=True):
+        for root, ball_cushion_pair in zip(roots, ball_cushion_pairs):
             cache[ball_cushion_pair] = shot.t + root
 
     # The cache is now populated and up-to-date
@@ -487,7 +487,7 @@ def get_next_ball_pocket_collision(
 
     if len(collision_coeffs):
         roots = solve_quartics(ps=np.array(collision_coeffs), solver=solver)
-        for root, ball_pocket_pair in zip(roots, ball_pocket_pairs, strict=True):
+        for root, ball_pocket_pair in zip(roots, ball_pocket_pairs):
             cache[ball_pocket_pair] = shot.t + root
 
     # The cache is now populated and up-to-date

--- a/pooltool/evolution/event_based/simulate.py
+++ b/pooltool/evolution/event_based/simulate.py
@@ -448,7 +448,7 @@ def get_next_ball_pocket_collision(
 ) -> Event:
     """Returns next ball-pocket collision"""
 
-    if not shot.table.has_circular_cushions:
+    if not shot.table.has_pockets:
         return null_event(np.inf)
 
     ball_pocket_pairs: List[Tuple[str, str]] = []

--- a/pooltool/evolution/event_based/test_simulate.py
+++ b/pooltool/evolution/event_based/test_simulate.py
@@ -173,7 +173,7 @@ def test_case3(solver: quartic.QuarticSolver):
     expected = pytest.approx(5.810383731499328e-06, abs=1e-9)
 
     assert event.time == expected
-    assert quartic.minimum_quartic_root(coeffs_array, solver=solver)[0] == expected
+    assert quartic.solve_quartics(coeffs_array, solver=solver)[0] == expected
 
 
 @pytest.mark.parametrize(
@@ -319,7 +319,7 @@ def test_grazing_ball_ball_collision(solver: quartic.QuarticSolver):
 
         coeffs_array = np.array([coeffs], dtype=np.float64)
 
-        root = quartic.minimum_quartic_root(coeffs_array)[0]
+        root = quartic.solve_quartics(coeffs_array)[0]
 
         if phi < 90:
             assert root == np.inf
@@ -423,7 +423,7 @@ def test_almost_touching_ball_ball_collision(solver: quartic.QuarticSolver):
         coeffs_array = np.array([coeffs], dtype=np.float64)
 
         truth = true_time_to_collision(eps, V0, ball1.params.u_r, ball1.params.g)
-        calculated = quartic.minimum_quartic_root(coeffs_array, solver=solver)[0]
+        calculated = quartic.solve_quartics(coeffs_array, solver=solver)[0]
         diff = abs(calculated - truth)
 
         assert diff < 10e-12  # Less than 10 femptosecond difference

--- a/pooltool/evolution/event_based/test_simulate.py
+++ b/pooltool/evolution/event_based/test_simulate.py
@@ -6,6 +6,7 @@ import pooltool.constants as const
 import pooltool.ptmath as ptmath
 from pooltool.events import EventType, ball_ball_collision, ball_pocket_collision
 from pooltool.evolution.event_based.simulate import (
+    CollisionCache,
     get_next_ball_ball_collision,
     get_next_event,
     simulate,
@@ -478,4 +479,7 @@ def test_no_ball_ball_collisions_for_intersecting_balls(solver: quartic.QuarticS
     assert (
         get_next_event(system, quartic_solver=solver).event_type != EventType.BALL_BALL
     )
-    assert get_next_ball_ball_collision(system, solver=solver).time == np.inf
+    assert (
+        get_next_ball_ball_collision(system, CollisionCache(), solver=solver).time
+        == np.inf
+    )

--- a/pooltool/evolution/event_based/test_simulate.py
+++ b/pooltool/evolution/event_based/test_simulate.py
@@ -5,8 +5,8 @@ from numpy.typing import NDArray
 import pooltool.constants as const
 import pooltool.ptmath as ptmath
 from pooltool.events import EventType, ball_ball_collision, ball_pocket_collision
+from pooltool.evolution.event_based.cache import CollisionCache
 from pooltool.evolution.event_based.simulate import (
-    CollisionCache,
     get_next_ball_ball_collision,
     get_next_event,
     simulate,

--- a/pooltool/objects/table/datatypes.py
+++ b/pooltool/objects/table/datatypes.py
@@ -102,6 +102,18 @@ class Table:
 
         return self.w / 2, self.l / 2
 
+    @property
+    def has_linear_cushions(self) -> bool:
+        return bool(len(self.cushion_segments.linear))
+
+    @property
+    def has_circular_cushions(self) -> bool:
+        return bool(len(self.cushion_segments.circular))
+
+    @property
+    def has_pockets(self) -> bool:
+        return bool(len(self.pockets))
+
     def copy(self) -> Table:
         """Create a copy."""
         # Delegates the deep-ish copying of CushionSegments and Pocket to their respective

--- a/pooltool/ptmath/roots/__init__.py
+++ b/pooltool/ptmath/roots/__init__.py
@@ -1,11 +1,9 @@
 import pooltool.ptmath.roots.quadratic as quadratic
 import pooltool.ptmath.roots.quartic as quartic
-from pooltool.ptmath.roots.core import min_real_root
-from pooltool.ptmath.roots.quartic import minimum_quartic_root
+from pooltool.ptmath.roots.quartic import solve_quartics
 
 __all__ = [
     "quadratic",
     "quartic",
-    "min_real_root",
-    "minimum_quartic_root",
+    "solve_quartics",
 ]

--- a/pooltool/ptmath/roots/core.py
+++ b/pooltool/ptmath/roots/core.py
@@ -1,118 +1,19 @@
-from typing import Tuple
-
 import numpy as np
-from numba import jit
 from numpy.typing import NDArray
 
-import pooltool.constants as const
 
-
-def min_real_root_old(
+def get_real_positive_smallest_roots(
     roots: NDArray[np.complex128],
     abs_or_rel_cutoff: float = 1e-3,
     rtol: float = 1e-3,
     atol: float = 1e-9,
-) -> np.complex128:
-    """Given an array of roots, find the minimum, real, positive root
-
-    Note: This is faster than a numba vector implementation and a numba loop
-    implementation.
+) -> NDArray[np.float64]:
+    """Returns the smallest postive and real root for each set of roots.
 
     Args:
         roots:
-            A 1D array of roots.
-        abs_or_rel_cutoff:
-            The criteria for a root being real depends on the magnitude of it's real
-            component. If it's large, we require the imaginary component to be less than
-            atol in absolute terms. But when the real component is small, we require the
-            imaginary component be less than a fraction, rtol, of the real component.
-            This is because when the real component is small, perhaps even comparable to
-            atol, using an absolute cutoff for the imaginary component doesn't make much
-            sense. abs_or_rel_cutoff defines a threshold for the magnitude of the real
-            component, above which atol is used and below which rtol is used.
-        atol:
-            A root r (with abs(r.real) >= abs_or_rel_cutoff) is considered real if
-            abs(r.imag) < atol.
-        rtol:
-            A root r (with abs(r.real) < abs_or_rel_cutoff) is considered real if
-            abs(r.imag) / abs(r.real) < rtol. And in the special case when r.real == 0,
-            the root is considered real if r.imag == 0, too.
-
-    Returns:
-        root:
-            The root determined to be smallest, real, and positive. Note, a complex
-            datatype is returned, and it may have residual complex components. Use
-            root.real for only the real component.
-    """
-    positive = roots.real >= 0.0
-
-    imag_mag = np.abs(roots.imag)
-    real_mag = np.abs(roots.real)
-
-    big = real_mag > abs_or_rel_cutoff
-    big_keep = (imag_mag < atol) & positive
-
-    small = real_mag <= abs_or_rel_cutoff
-    small_keep1 = (real_mag > 0) & ((imag_mag / real_mag) < rtol)
-    small_keep2 = (real_mag == 0) & (imag_mag == 0)
-    small_keep = (small_keep1 | small_keep2) & positive
-
-    candidates = roots[(small & small_keep) | (big & big_keep)]
-
-    if candidates.size == 0:
-        return np.complex128(np.inf)
-
-    # Return candidate with the smallest real component
-    return candidates[candidates.real.argmin()]
-
-
-def min_real_root(
-    roots: NDArray[np.complex128],
-    abs_or_rel_cutoff: float = 1e-3,
-    rtol: float = 1e-3,
-    atol: float = 1e-9,
-) -> np.complex128:
-    """Find the minimum real positive root, using the processed roots from process_roots.
-
-    Args:
-        roots:
-            A 1D array of roots.
-        abs_or_rel_cutoff:
-            The criteria for a root being real depends on the magnitude of its real
-            component.
-        atol:
-            A root r (with abs(r.real) >= abs_or_rel_cutoff) is considered real if
-            abs(r.imag) < atol.
-        rtol:
-            A root r (with abs(r.real) < abs_or_rel_cutoff) is considered real if
-            abs(r.imag) / abs(r.real) < rtol.
-
-    Returns:
-        root:
-            The smallest, real, positive root. Returns np.inf if no such root exists.
-    """
-    # Process the roots to filter out non-real roots
-    roots, is_real = process_roots(roots, abs_or_rel_cutoff, rtol, atol)
-
-    # Select the smallest real root (which are not set to np.inf)
-    if roots.size == 0 or np.all(roots == np.inf):
-        return np.complex128(np.inf)
-
-    min_root = np.min(roots[is_real])
-    return np.complex128(min_root)
-
-
-def process_roots(
-    roots: NDArray[np.complex128],
-    abs_or_rel_cutoff: float = 1e-3,
-    rtol: float = 1e-3,
-    atol: float = 1e-9,
-) -> Tuple[NDArray[np.complex128], NDArray[np.bool]]:
-    """Process roots and return an array where non-real roots are set to inf.
-
-    Args:
-        roots:
-            A 1D array of roots.
+            A mxn array of polynomial root solutions, where m is the number of equations
+            and n is the order of the polynomial.
         abs_or_rel_cutoff:
             The criteria for a root being real depends on the magnitude of its real
             component. If it's large, we require the imaginary component to be less than
@@ -129,9 +30,9 @@ def process_roots(
             the root is considered real if r.imag == 0, too.
 
     Returns:
-        (NDArray[np.complex128], NDArray[np.bool]):
-            - roots: The processed roots where non-real roots are set to infinity.
-            - is_real: A boolean array indicating which roots are considered real.
+            An array of shape m. Each value is the smallest root that is real and
+            positive. If no such root exists (e.g. all roots are complex), then
+            `np.inf` is used.
     """
     positive = roots.real >= 0.0
 
@@ -149,14 +50,7 @@ def process_roots(
     is_real = (small & small_keep) | (big & big_keep)
     processed_roots = np.where(is_real, roots, np.complex128(np.inf))
 
-    return processed_roots, is_real
+    # Find the minimum real positive root in each row
+    min_real_positive_roots = np.min(processed_roots.real, axis=1)
 
-
-@jit(nopython=True, cache=const.use_numba_cache)
-def find_first_row_with_value(arr, X) -> int:
-    """Find the index of the first row in a 2D array that contains a specific value."""
-    for i in range(arr.shape[0]):
-        for j in range(arr.shape[1]):
-            if arr[i, j] == X:
-                return i
-    return -1
+    return min_real_positive_roots

--- a/pooltool/ptmath/roots/core.py
+++ b/pooltool/ptmath/roots/core.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import numpy as np
 from numba import jit
 from numpy.typing import NDArray
@@ -5,7 +7,7 @@ from numpy.typing import NDArray
 import pooltool.constants as const
 
 
-def min_real_root(
+def min_real_root_old(
     roots: NDArray[np.complex128],
     abs_or_rel_cutoff: float = 1e-3,
     rtol: float = 1e-3,
@@ -62,6 +64,92 @@ def min_real_root(
 
     # Return candidate with the smallest real component
     return candidates[candidates.real.argmin()]
+
+
+def min_real_root(
+    roots: NDArray[np.complex128],
+    abs_or_rel_cutoff: float = 1e-3,
+    rtol: float = 1e-3,
+    atol: float = 1e-9,
+) -> np.complex128:
+    """Find the minimum real positive root, using the processed roots from process_roots.
+
+    Args:
+        roots:
+            A 1D array of roots.
+        abs_or_rel_cutoff:
+            The criteria for a root being real depends on the magnitude of its real
+            component.
+        atol:
+            A root r (with abs(r.real) >= abs_or_rel_cutoff) is considered real if
+            abs(r.imag) < atol.
+        rtol:
+            A root r (with abs(r.real) < abs_or_rel_cutoff) is considered real if
+            abs(r.imag) / abs(r.real) < rtol.
+
+    Returns:
+        root:
+            The smallest, real, positive root. Returns np.inf if no such root exists.
+    """
+    # Process the roots to filter out non-real roots
+    roots, is_real = process_roots(roots, abs_or_rel_cutoff, rtol, atol)
+
+    # Select the smallest real root (which are not set to np.inf)
+    if roots.size == 0 or np.all(roots == np.inf):
+        return np.complex128(np.inf)
+
+    min_root = np.min(roots[is_real])
+    return np.complex128(min_root)
+
+
+def process_roots(
+    roots: NDArray[np.complex128],
+    abs_or_rel_cutoff: float = 1e-3,
+    rtol: float = 1e-3,
+    atol: float = 1e-9,
+) -> Tuple[NDArray[np.complex128], NDArray[np.bool]]:
+    """Process roots and return an array where non-real roots are set to inf.
+
+    Args:
+        roots:
+            A 1D array of roots.
+        abs_or_rel_cutoff:
+            The criteria for a root being real depends on the magnitude of its real
+            component. If it's large, we require the imaginary component to be less than
+            atol in absolute terms. But when the real component is small, we require the
+            imaginary component be less than a fraction, rtol, of the real component.
+            abs_or_rel_cutoff defines a threshold for the magnitude of the real
+            component, above which atol is used and below which rtol is used.
+        atol:
+            A root r (with abs(r.real) >= abs_or_rel_cutoff) is considered real if
+            abs(r.imag) < atol.
+        rtol:
+            A root r (with abs(r.real) < abs_or_rel_cutoff) is considered real if
+            abs(r.imag) / abs(r.real) < rtol. And in the special case when r.real == 0,
+            the root is considered real if r.imag == 0, too.
+
+    Returns:
+        (NDArray[np.complex128], NDArray[np.bool]):
+            - roots: The processed roots where non-real roots are set to infinity.
+            - is_real: A boolean array indicating which roots are considered real.
+    """
+    positive = roots.real >= 0.0
+
+    imag_mag = np.abs(roots.imag)
+    real_mag = np.abs(roots.real)
+
+    big = real_mag > abs_or_rel_cutoff
+    big_keep = (imag_mag < atol) & positive
+
+    small = real_mag <= abs_or_rel_cutoff
+    small_keep1 = (real_mag > 0) & ((imag_mag / real_mag) < rtol)
+    small_keep2 = (real_mag == 0) & (imag_mag == 0)
+    small_keep = (small_keep1 | small_keep2) & positive
+
+    is_real = (small & small_keep) | (big & big_keep)
+    processed_roots = np.where(is_real, roots, np.complex128(np.inf))
+
+    return processed_roots, is_real
 
 
 @jit(nopython=True, cache=const.use_numba_cache)

--- a/pooltool/ptmath/roots/test_quartic.py
+++ b/pooltool/ptmath/roots/test_quartic.py
@@ -18,7 +18,7 @@ def test_case1(solver: quartic.QuarticSolver):
 
     expected = 0.048943195217641386
     coeffs_array = np.array(coeffs)[np.newaxis, :]
-    assert quartic.minimum_quartic_root(coeffs_array, solver)[0] == pytest.approx(
+    assert quartic.solve_quartics(coeffs_array, solver)[0] == pytest.approx(
         expected, rel=1e-4
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ colored = ">=2.2.4"  # TODO switch to something ubiquitous
 ipython = ">=8.18.1"
 # Publishing
 poetry-dynamic-versioning = {extras = ["plugin"], version = ">=1.4.0"}
+ipdb = "^0.13.13"
 
 [tool.poetry.group.docs]
 optional = true


### PR DESCRIPTION
Based on reviewer feedback (https://github.com/pyOpenSci/software-submission/issues/173), an idea sprouted to cache event times to avoid recalculation at every step of the shot evolution algorithm. This PR implements that.

The results yield improvements in simulation time for random simulations, using ball number as a parameter for simulation complexity:

![image](https://github.com/user-attachments/assets/abee0877-5139-445d-812a-af581a9320a6)

The improvement is more dramatic when the number of balls is dramatically increased:

![image](https://github.com/user-attachments/assets/7fddb15e-9cd7-4624-bc8d-8af8cc15b448)
