### PR TITLE
Better window management

### DIFF
--- a/pooltool/ani/animate.py
+++ b/pooltool/ani/animate.py
@@ -434,7 +434,7 @@ class ShotViewer(Interface):
         else:
             cam.load_state(camera_state)
 
-        self.standby_screen.hide()
+        # self.standby_screen.hide()
         self._create_title(title)
         self.title_node.show()
 
@@ -484,11 +484,17 @@ class ShotViewer(Interface):
     def _start(self):
         # self.openMainWindow(keepCamera=True)
 
-        self.openMainWindow(
-            fbprops=self.showbase_config.fb_prop,
-            size=self.showbase_config.window_size,
-            keepCamera=True,
-        )
+        # self.openMainWindow(
+        #    fbprops=self.showbase_config.fb_prop,
+        #    size=self.showbase_config.window_size,
+        #    keepCamera=True,
+        # )
+
+        from panda3d.core import WindowProperties
+
+        winprop = WindowProperties()
+        winprop.minimized = False
+        self.win.requestProperties(winprop)
 
         # Background doesn't apply if ran after simplepbr.init(). See
         # https://discourse.panda3d.org/t/cant-change-base-background-after-simplepbr-init/28945
@@ -506,15 +512,21 @@ class ShotViewer(Interface):
     def _stop(self):
         """Display the standby screen and halt the main loop"""
 
-        self.standby_screen.show()
-        self.title_node.hide()
+        # self.standby_screen.show()
+        # self.title_node.hide()
 
-        # Advance a couple of frames to render changes
-        boop(2)
+        from panda3d.core import WindowProperties
+
+        winprop = WindowProperties()
+        winprop.minimized = True
+        self.win.requestProperties(winprop)
 
         # win = self.win
-        self.closeWindow(self.win, keepCamera=True, removeWindow=True)
+        # self.closeWindow(self.win, keepCamera=True, removeWindow=True)
         # self.win = win
+
+        # Advance a couple of frames to render changes
+        boop(100)
 
         # Stop the main loop
         Global.task_mgr.stop()

--- a/pooltool/ani/animate.py
+++ b/pooltool/ani/animate.py
@@ -112,6 +112,13 @@ def _resize_offscreen_window(size: Tuple[int, int]):
     Global.base.win.setSize(*[int(dim) for dim in size])
 
 
+def _init_simplepbr():
+    simplepbr.init(
+        enable_shadows=ani.settings["graphics"]["shadows"],
+        max_lights=ani.settings["graphics"]["max_lights"],
+    )
+
+
 class Interface(ShowBase):
     def __init__(self, config: ShowBaseConfig):
         self.showbase_config = config
@@ -124,10 +131,6 @@ class Interface(ShowBase):
         # Background doesn't apply if ran after simplepbr.init(). See
         # https://discourse.panda3d.org/t/cant-change-base-background-after-simplepbr-init/28945
         Global.base.setBackgroundColor(0.04, 0.04, 0.04)
-
-        simplepbr.init(
-            enable_shadows=ani.settings["graphics"]["shadows"], max_lights=13
-        )
 
         if isinstance(self.win, GraphicsWindow):
             mouse.init()
@@ -333,7 +336,6 @@ class ShotViewer(Interface):
 
     def __init__(self, config=ShowBaseConfig.default()):
         Interface.__init__(self, config=config)
-        self._create_standby_screen()
         self._create_title("")
 
         # Set ShotMode to view only. This prevents giving cue stick control to the user
@@ -345,7 +347,7 @@ class ShotViewer(Interface):
     def show(
         self,
         shot_or_shots: Union[System, MultiSystem],
-        title: str = "",
+        title: str = "Press <esc> to continue program execution",
         camera_state: Optional[CameraState] = None,
     ):
         """Opens the interactive interface for one or more shots.
@@ -390,33 +392,6 @@ class ShotViewer(Interface):
             >>> gui.show(system)
 
             (Press *escape* to exit the interface and continue script execution)
-
-        Example:
-
-            This example explains the order in which events and script execution
-            happens.
-
-            .. code-block:: python
-
-                import pooltool as pt
-                system = pt.System.example()
-                pt.simulate(system, inplace=True)
-
-                # This line takes a view seconds to execute. It will generate a visible
-                # window. Once the window has been generated, script execution continues
-                gui = pt.ShotViewer()
-
-                # When this line is called, the window is populated with an animated
-                # scene of the shot.
-                gui.show(system)
-
-                # This line will not execute until <esc> is pressed while the window is
-                # active.
-                print('script continues')
-
-                # For subsequent calls to `show`, you must use the same `ShotViewer`
-                # object:
-                gui.show(system)
         """
         self._start()
 
@@ -434,7 +409,6 @@ class ShotViewer(Interface):
         else:
             cam.load_state(camera_state)
 
-        # self.standby_screen.hide()
         self._create_title(title)
         self.title_node.show()
 
@@ -465,62 +439,13 @@ class ShotViewer(Interface):
         )
         self.title_node.hide()
 
-    def _create_standby_screen(self):
-        self.standby_screen = GenericMenu(frame_color=(0.3, 0.3, 0.3, 1))
-        self.standby_screen.add_image(
-            ani.logo_paths["default"], pos=(0, 0, 0), scale=(0.5, 1, 0.44)
-        )
-
-        autils.CustomOnscreenText(
-            text="GUI standing by...",
-            style=1,
-            fg=(1, 1, 1, 1),
-            parent=self.standby_screen.titleMenu,
-            align=TextNode.ALeft,
-            pos=(-1.55, 0.93),
-            scale=0.8 * ani.menu_text_scale,
-        )
-
     def _start(self):
-        # self.openMainWindow(keepCamera=True)
-
-        # self.openMainWindow(
-        #    fbprops=self.showbase_config.fb_prop,
-        #    size=self.showbase_config.window_size,
-        #    keepCamera=True,
-        # )
-        # self.win = self.oldwin
-        # self.cam = self.oldcam
-        # self.camLens = self.oldlens
-        # self.win.setActive(True)
         self.openMainWindow(keepCamera=True)
-        self.graphicsEngine.openWindows()
-
-        # Background doesn't apply if ran after simplepbr.init(). See
-        # https://discourse.panda3d.org/t/cant-change-base-background-after-simplepbr-init/28945
-        Global.base.setBackgroundColor(0.04, 0.04, 0.04)
-
-        simplepbr.init(
-            enable_shadows=ani.settings["graphics"]["shadows"], max_lights=13
-        )
-
-        if isinstance(self.win, GraphicsWindow):
-            mouse.init()
-
-        cam.init()
+        _init_simplepbr()
+        mouse.init()
 
     def _stop(self):
-        """Display the standby screen and halt the main loop"""
-
-        # self.standby_screen.show()
-        # self.title_node.hide()
-
-        self.oldwin = self.win
-        self.oldcam = self.cam
-        self.oldlens = self.camLens
-        self.closeWindow(self.win, keepCamera=True, removeWindow=True)
-
-        # Stop the main loop
+        self.closeWindow(self.win)
         Global.task_mgr.stop()
 
 

--- a/pooltool/ani/animate.py
+++ b/pooltool/ani/animate.py
@@ -489,20 +489,20 @@ class ShotViewer(Interface):
         #    size=self.showbase_config.window_size,
         #    keepCamera=True,
         # )
-
-        from panda3d.core import WindowProperties
-
-        winprop = WindowProperties()
-        winprop.minimized = False
-        self.win.requestProperties(winprop)
+        # self.win = self.oldwin
+        # self.cam = self.oldcam
+        # self.camLens = self.oldlens
+        # self.win.setActive(True)
+        self.openMainWindow(keepCamera=True)
+        self.graphicsEngine.openWindows()
 
         # Background doesn't apply if ran after simplepbr.init(). See
         # https://discourse.panda3d.org/t/cant-change-base-background-after-simplepbr-init/28945
         Global.base.setBackgroundColor(0.04, 0.04, 0.04)
 
-        # simplepbr.init(
-        #    enable_shadows=ani.settings["graphics"]["shadows"], max_lights=13
-        # )
+        simplepbr.init(
+            enable_shadows=ani.settings["graphics"]["shadows"], max_lights=13
+        )
 
         if isinstance(self.win, GraphicsWindow):
             mouse.init()
@@ -515,18 +515,10 @@ class ShotViewer(Interface):
         # self.standby_screen.show()
         # self.title_node.hide()
 
-        from panda3d.core import WindowProperties
-
-        winprop = WindowProperties()
-        winprop.minimized = True
-        self.win.requestProperties(winprop)
-
-        # win = self.win
-        # self.closeWindow(self.win, keepCamera=True, removeWindow=True)
-        # self.win = win
-
-        # Advance a couple of frames to render changes
-        boop(100)
+        self.oldwin = self.win
+        self.oldcam = self.cam
+        self.oldlens = self.camLens
+        self.closeWindow(self.win, keepCamera=True, removeWindow=True)
 
         # Stop the main loop
         Global.task_mgr.stop()

--- a/pooltool/ani/animate.py
+++ b/pooltool/ani/animate.py
@@ -513,7 +513,7 @@ class ShotViewer(Interface):
         boop(2)
 
         # win = self.win
-        self.closeWindow(self.win, keepCamera=True, removeWindow=False)
+        self.closeWindow(self.win, keepCamera=True, removeWindow=True)
         # self.win = win
 
         # Stop the main loop

--- a/pooltool/ani/animate.py
+++ b/pooltool/ani/animate.py
@@ -132,6 +132,8 @@ class Interface(ShowBase):
         # https://discourse.panda3d.org/t/cant-change-base-background-after-simplepbr-init/28945
         Global.base.setBackgroundColor(0.04, 0.04, 0.04)
 
+        _init_simplepbr()
+
         if isinstance(self.win, GraphicsWindow):
             mouse.init()
 
@@ -453,7 +455,7 @@ class Game(Interface):
     """This class runs the pooltool application"""
 
     def __init__(self, config=ShowBaseConfig.default()):
-        Interface.__init__(self, showbase_config=config)
+        Interface.__init__(self, config=config)
 
         # FIXME can this be added to MenuMode.enter? It produces a lot of events that
         # end up being part of the baseline due to the update_event_baseline call below.

--- a/pooltool/config/settings
+++ b/pooltool/config/settings
@@ -5,6 +5,7 @@ table = 1
 shadows = 0
 shader = 1
 lights = 1
+max_lights = 13
 physical_based_rendering = 0
 debug = 0
 fps = 45

--- a/pooltool/interact.py
+++ b/pooltool/interact.py
@@ -1,19 +1,13 @@
 """An endpoint for classes that enable interaction"""
 
-from typing import Optional, Union
+from typing import Optional
 
 from pooltool.ani.animate import Game, ShotViewer
-from pooltool.ani.camera import CameraState
-from pooltool.system.datatypes import MultiSystem, System
 
 _shot_viewer: Optional[ShotViewer] = None
 
 
-def show(
-    shot_or_shots: Union[System, MultiSystem],
-    title: str = "",
-    camera_state: Optional[CameraState] = None,
-):
+def show(*args, **kwargs):
     """Opens the interactive interface for one or more shots.
 
     Important:
@@ -58,7 +52,7 @@ def show(
     if _shot_viewer is None:
         _shot_viewer = ShotViewer()
 
-    _shot_viewer.show(shot_or_shots, title, camera_state)
+    _shot_viewer.show(*args, **kwargs)
 
 
 __all__ = [


### PR DESCRIPTION
When `pt.show()` is called, it used to be the case that a window would pop up and stay perpetually until the end of program. Now, a window pops up, and persists only until the user presses escape, upon which the window closes and program execution continues.