### PR TITLE
Two players by default

### DIFF
--- a/pooltool/ani/animate.py
+++ b/pooltool/ani/animate.py
@@ -506,7 +506,8 @@ class Game(Interface):
 
         game = get_ruleset(game_type)()
         game.players = [
-            Player("Player"),
+            Player("Player 1"),
+            Player("Player 2"),
         ]
 
         table = Table.from_game_type(game_type)

--- a/pooltool/objects/table/collection.py
+++ b/pooltool/objects/table/collection.py
@@ -91,6 +91,7 @@ _default_game_type_map: Dict[GameType, TableName] = {
     GameType.SNOOKER: TableName.SNOOKER_GENERIC,
     GameType.THREECUSHION: TableName.BILLIARD_WIP,
     GameType.SUMTOTHREE: TableName.SUMTOTHREE_WIP,
+    GameType.SANDBOX: TableName.SEVEN_FOOT_SHOWOOD,
 }
 
 


### PR DESCRIPTION
Since all game types support 2 players, increase the default player count to 2.

Fixes this error: https://discord.com/channels/1116210227688255601/1116210897136926771/1319874536711389244