### PR TITLE
Enable z-dimension in stick-ball collision

### DIFF
--- a/pooltool/evolution/event_based/simulate.py
+++ b/pooltool/evolution/event_based/simulate.py
@@ -166,7 +166,7 @@ def simulate(
         engine = DEFAULT_ENGINE
 
     shot.reset_history()
-    shot._update_history(null_event(time=0))
+    shot._update_history(null_event(time=0.0))
 
     if _get_system_energy(shot) == 0 and shot.cue.V0 > 0:
         # System has no energy, but the cue stick has an impact velocity. So create and
@@ -174,7 +174,7 @@ def simulate(
         event = stick_ball_collision(
             stick=shot.cue,
             ball=shot.balls[shot.cue.cue_ball_id],
-            time=0,
+            time=0.0,
             set_initial=True,
         )
         engine.resolver.resolve(shot, event)

--- a/pooltool/physics/resolve/stick_ball/core.py
+++ b/pooltool/physics/resolve/stick_ball/core.py
@@ -1,8 +1,30 @@
 from abc import ABC, abstractmethod
 from typing import Protocol, Tuple
 
+import numpy as np
+from numpy.typing import NDArray
+
+import pooltool.constants as const
 from pooltool.objects.ball.datatypes import Ball
 from pooltool.objects.cue.datatypes import Cue
+
+
+def final_ball_motion_state(rvw: NDArray[np.float64], R: float) -> int:
+    """Return the final (post-collision) motion state label.
+
+    If the z-velocity is non-zero, it is considered airborne, otherwise it is sliding.
+
+    Args:
+        rvw: The outgoing state vector of the ball.
+        R: The radius of the ball.
+
+    Notes:
+        - A universal final_ball_motion_state fn could be a good idea.
+    """
+    if rvw[1, 2] != 0.0:
+        return const.airborne
+
+    return const.sliding
 
 
 class _BaseStrategy(Protocol):

--- a/pooltool/physics/resolve/stick_ball/instantaneous_point/__init__.py
+++ b/pooltool/physics/resolve/stick_ball/instantaneous_point/__init__.py
@@ -3,12 +3,14 @@ from typing import Tuple
 import attrs
 import numpy as np
 
-import pooltool.constants as const
 import pooltool.ptmath as ptmath
 from pooltool.objects.ball.datatypes import Ball, BallState
 from pooltool.objects.cue.datatypes import Cue
 from pooltool.physics.resolve.models import StickBallModel
-from pooltool.physics.resolve.stick_ball.core import CoreStickBallCollision
+from pooltool.physics.resolve.stick_ball.core import (
+    CoreStickBallCollision,
+    final_ball_motion_state,
+)
 from pooltool.physics.resolve.stick_ball.squirt import get_squirt_angle
 from pooltool.ptmath.utils import coordinate_rotation
 
@@ -91,8 +93,7 @@ def cue_strike(m, M, R, V0, phi, theta, a, b, english_throttle: float):
     v = numerator / denominator
 
     # 3D FIXME
-    # v_B = -v * np.array([0, np.cos(theta), np.sin(theta)])
-    v_B = -v * np.array([0, np.cos(theta), 0])
+    v_B = -v * np.array([0, np.cos(theta), np.sin(theta)])
 
     vec_x = -c * np.sin(theta) + b * np.cos(theta)
     vec_y = a * np.sin(theta)
@@ -152,7 +153,8 @@ class InstantaneousPoint(CoreStickBallCollision):
         v = coordinate_rotation(v, alpha)
 
         rvw = np.array([ball.state.rvw[0], v, w])
-        s = const.sliding
+
+        s = final_ball_motion_state(rvw, ball.params.R)
 
         ball.state = BallState(rvw, s)
 


### PR DESCRIPTION
The stick-ball collision now imparts z-momentum to the cue ball.

If you play around with this, you'll see just how unrealistic the current model is. In particular, it seems impossible to hit a "knuckle ball" jump shot--backspin is always applied.

A note about future models: models can either model the stick-ball-table interaction as a whole, yielding a positive outgoing z-momentum, or they can just model the stick-ball interaction, yielding a negative outgoing z-momentum. In the former case,  the ball will undergo an airborne trajectory, and in the latter, a ball-table collision will be detected at a time t=0 later.