### PR TITLE
Catch near-zero case in quadratic solver

### DIFF
--- a/pooltool/ptmath/roots/quadratic.py
+++ b/pooltool/ptmath/roots/quadratic.py
@@ -1,5 +1,6 @@
 from typing import Tuple
 
+import numpy as np
 from numba import jit
 
 import pooltool.constants as const
@@ -8,7 +9,7 @@ import pooltool.constants as const
 @jit(nopython=True, cache=const.use_numba_cache)
 def solve(a: float, b: float, c: float) -> Tuple[float, float]:
     """Solve a quadratic equation At^2 + Bt + C = 0 (just-in-time compiled)"""
-    if a == 0:
+    if np.abs(a) < const.EPS:
         u = -c / b
         return u, u
     bp = b / 2

--- a/tests/physics/resolve/ball_cushion/test_ball_cushion.py
+++ b/tests/physics/resolve/ball_cushion/test_ball_cushion.py
@@ -22,7 +22,12 @@ def cushion_yaxis():
 
 
 @pytest.mark.parametrize(
-    "model_name", [BallLCushionModel.HAN_2005, BallLCushionModel.UNREALISTIC]
+    "model_name",
+    [
+        BallLCushionModel.HAN_2005,
+        BallLCushionModel.UNREALISTIC,
+        BallLCushionModel.MATHAVAN_2010,
+    ],
 )
 def test_symmetry(
     cushion_yaxis: LinearCushionSegment, model_name: BallLCushionModel
@@ -69,4 +74,4 @@ def test_symmetry(
         assert np.isclose(ball_after.state.rvw[1, 0], other_after.state.rvw[1, 0])
 
         # Y-velocities are reflected
-        assert ball_after.state.rvw[1, 1] == -other_after.state.rvw[1, 1]
+        assert np.isclose(ball_after.state.rvw[1, 1], -other_after.state.rvw[1, 1])


### PR DESCRIPTION
- Add Mathavan to unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved numerical handling in the quadratic solver to better treat near-zero values, resulting in more reliable calculations.
  
- **Tests**
  - Enhanced physics simulation validations by expanding model scenarios and using more robust comparisons, ensuring improved consistency in ball-cushion interaction outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->