### PR TITLE
Billiard cushion height buff

### DIFF
--- a/docs/examples/30_degree_rule.pct.py
+++ b/docs/examples/30_degree_rule.pct.py
@@ -313,6 +313,7 @@ data = {
 V0 = 2.5
 
 for cut_angle in np.linspace(0, 88, 50):
+    print(f"{cut_angle=}")
     system = simulate_experiment(V0, cut_angle)
     data["theta"].append(get_carom_angle(system))
     data["f"].append(get_ball_hit_fraction(cut_angle))

--- a/pooltool/ani/__init__.py
+++ b/pooltool/ani/__init__.py
@@ -11,6 +11,7 @@ from panda3d.core import loadPrcFileData
 
 import pooltool as pt
 from pooltool.config.user import CONFIG_DIR
+from pooltool.game.datatypes import GameType
 from pooltool.serialize import conversion
 from pooltool.terminal import Run
 from pooltool.utils import panda_path
@@ -112,6 +113,7 @@ class GraphicsConfig:
 @attrs.define
 class GameplayConfig:
     cue_collision: int = True
+    game_type: GameType = GameType.NINEBALL
 
 
 @attrs.define

--- a/pooltool/ani/animate.py
+++ b/pooltool/ani/animate.py
@@ -30,7 +30,6 @@ from pooltool.ani.modes import Mode, ModeManager, all_modes
 from pooltool.ani.mouse import mouse
 from pooltool.evolution import simulate
 from pooltool.evolution.continuize import continuize
-from pooltool.game.datatypes import GameType
 from pooltool.layouts import get_rack
 from pooltool.objects.cue.datatypes import Cue
 from pooltool.objects.table.datatypes import Table
@@ -447,6 +446,7 @@ class ShotViewer(Interface):
         mouse.init()
 
     def _stop(self):
+        self.title_node.destroy()
         self.closeWindow(self.win)
         Global.task_mgr.stop()
 
@@ -500,9 +500,10 @@ class Game(Interface):
         FIXME This is where menu options for game type and further specifications should
         plug into.
         """
-        # Change this line to change the game played.
-        # Pick from {NINEBALL, EIGHTBALL, THREECUSHION, SNOOKER, SANDBOX}
-        game_type = GameType.NINEBALL
+        # Change the gametype by editing ~/.config/pooltool/general.yaml
+        # Available options:
+        #   {eightball, nineball, threecushion, snooker, sandbox, sumtothree}
+        game_type = ani.settings.gameplay.game_type
 
         game = get_ruleset(game_type)()
         game.players = [

--- a/pooltool/objects/table/specs.py
+++ b/pooltool/objects/table/specs.py
@@ -129,9 +129,10 @@ class BilliardTableSpecs:
     l: float = field(default=3.05)  # noqa  E741
     w: float = field(default=3.05 / 2)
 
-    # FIXME height should be adjusted for 3-cushion sized balls
     cushion_width: float = field(default=2 * 2.54 / 100)
-    cushion_height: float = field(default=0.64 * 2 * 0.028575)
+
+    # https://web.archive.org/web/20130801042614/http://www.umb.org/Rules/Carom_Rules.pdf
+    cushion_height: float = field(default=0.037)
 
     # For visualization
     height: float = field(default=0.708)

--- a/tests/objects/table/test_datatypes.py
+++ b/tests/objects/table/test_datatypes.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from pooltool.objects.table.datatypes import Table
@@ -20,3 +21,41 @@ def test_table_copy(table):
 
     # `model_descr` object _is_ shared, but its frozen so its OK
     assert new.model_descr is table.model_descr
+
+
+def test_set_cushion_height(table):
+    """Test that set_cushion_height correctly updates the height of all cushion segments."""
+    # Store initial values for verification
+    initial_linear = {
+        id: {"p1": segment.p1.copy(), "p2": segment.p2.copy()}
+        for id, segment in table.cushion_segments.linear.items()
+    }
+    initial_circular = {
+        id: {"center": segment.center.copy()}
+        for id, segment in table.cushion_segments.circular.items()
+    }
+
+    new_height = 0.85
+    table.set_cushion_height(new_height)
+
+    for id, segment in table.cushion_segments.linear.items():
+        # Height property updated
+        assert segment.height == new_height
+
+        # p1 and p2 z-coordinates updated
+        assert segment.p1[2] == new_height
+        assert segment.p2[2] == new_height
+
+        # x,y coordinates unchanged
+        assert np.array_equal(segment.p1[:2], initial_linear[id]["p1"][:2])
+        assert np.array_equal(segment.p2[:2], initial_linear[id]["p2"][:2])
+
+    for id, segment in table.cushion_segments.circular.items():
+        # Height property updated
+        assert segment.height == new_height
+
+        # center z-coordinate updated
+        assert segment.center[2] == new_height
+
+        # x,y coordinates unchanged
+        assert np.array_equal(segment.center[:2], initial_circular[id]["center"][:2])


### PR DESCRIPTION
Cushion height has a large influence on ball dynamics. I tracked the x-position of the 6th cushion hit in this shot over a range of cushion heights between 36mm and 38mm. According to [this reference](https://web.archive.org/web/20130801042614/http://www.umb.org/Rules/Carom_Rules.pdf) 37mm is standard and a 1mm tolerance is allowed.

![Mar-15-2025 16-31-45](https://github.com/user-attachments/assets/092e1b7d-1eaa-47f5-827c-2a2a364d7f81)

Within this range, we can see about 10cm variation in x-position:

<img width="1204" alt="image" src="https://github.com/user-attachments/assets/ebe11ea0-39d1-424d-9366-86473fc91f37" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Now you can customize gameplay by selecting a game mode via your configuration settings.
	- Table customization has been enhanced with dynamic cushion height adjustments for a refined playing experience.
  
- **Refactor**
	- Improved configuration retrieval and interface cleanup for enhanced stability.
	- Updated table specifications ensure consistent performance aligned with standard rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->