### PR TITLE
Change default ball-ball

### DIFF
--- a/docs/examples/30_degree_rule.pct.py
+++ b/docs/examples/30_degree_rule.pct.py
@@ -312,7 +312,7 @@ data = {
 
 V0 = 2.5
 
-for cut_angle in np.linspace(0, 88, 50):
+for cut_angle in np.linspace(2, 88, 50):
     print(f"{cut_angle=}")
     system = simulate_experiment(V0, cut_angle)
     data["theta"].append(get_carom_angle(system))

--- a/pooltool/physics/resolve/ball_ball/frictional_inelastic/__init__.py
+++ b/pooltool/physics/resolve/ball_ball/frictional_inelastic/__init__.py
@@ -99,9 +99,10 @@ def _resolve_ball_ball(rvw1, rvw2, R, u_b, e_b):
 class FrictionalInelastic(CoreBallBallCollision):
     """A simple ball-ball collision model including ball-ball friction, and coefficient of restitution for equal-mass balls
 
-    Largely inspired by Dr. David Alciatore's technical proofs (https://billiards.colostate.edu/technical_proofs),
-    in particular, TP_A-5, TP_A-6, and TP_A-14. These ideas have been extended to include motion of both balls,
-    and a more complete analysis of velocity and angular velocity in their vector forms.
+    Largely inspired by Dr. David Alciatore's technical proofs
+    (https://billiards.colostate.edu/technical_proofs), in particular, TP_A-5, TP_A-6,
+    and TP_A-14. These ideas have been extended to include motion of both balls, and a
+    more complete analysis of velocity and angular velocity in their vector forms.
     """
 
     friction: BallBallFrictionStrategy = AlciatoreBallBallFriction()

--- a/pooltool/physics/resolve/resolver.py
+++ b/pooltool/physics/resolve/resolver.py
@@ -18,7 +18,7 @@ from pooltool.physics.resolve.ball_ball import (
 from pooltool.physics.resolve.ball_ball.friction import (
     AlciatoreBallBallFriction,
 )
-from pooltool.physics.resolve.ball_ball.frictional_mathavan import FrictionalMathavan
+from pooltool.physics.resolve.ball_ball.frictional_inelastic import FrictionalInelastic
 from pooltool.physics.resolve.ball_cushion import (
     BallCCushionCollisionStrategy,
     BallLCushionCollisionStrategy,
@@ -47,7 +47,7 @@ from pooltool.terminal import Run
 RESOLVER_PATH = pooltool.config.user.PHYSICS_DIR / "resolver.yaml"
 """The location of the resolver path YAML."""
 
-VERSION: int = 7
+VERSION: int = 8
 
 
 run = Run()
@@ -65,13 +65,12 @@ def default_resolver() -> Resolver:
     The resolver YAML is found at `RESOLVER_PATH`.
     """
     return Resolver(
-        ball_ball=FrictionalMathavan(
+        ball_ball=FrictionalInelastic(
             friction=AlciatoreBallBallFriction(
                 a=0.009951,
                 b=0.108,
                 c=1.088,
             ),
-            num_iterations=1000,
         ),
         ball_linear_cushion=Mathavan2010Linear(
             max_steps=1000,


### PR DESCRIPTION
# Overview

This change comes in the wake of a few things.

First, it was realized that there is numerical instability in the ball-cushion Mathavan model. That has been fixed in https://github.com/ekiefl/pooltool/pull/192, but I suspect the same numerical instability exists in the ball-ball Mathavan model, and that definitely has not been addressed.

Second, and most importantly, we have reason to believe this is a more accurate model and it's definitely faster. Evidence for both these claims can be found in @derek-mcblane's PR that ironed out the final wrinkles of this model: https://github.com/ekiefl/pooltool/pull/177.

This model will debut in v0.4.4

# Drive-bys

* Messing around with the 30-degree example, trying to fix a CI build failure.