### PR TITLE
Correct dimensions

### DIFF
--- a/pooltool/layouts.py
+++ b/pooltool/layouts.py
@@ -373,7 +373,7 @@ def _get_three_cushion_rack(
     if ballset is None:
         ballset = DEFAULT_THREECUSH_BALLSET
 
-    white = BallPos([], (0.5+0.1825/1.42, 0.25), {"white"})
+    white = BallPos([], (0.5 + 0.1825 / 1.42, 0.25), {"white"})
     yellow = BallPos([], (0.5, 0.25), {"yellow"})
     red = BallPos([], (0.5, 0.75), {"red"})
 

--- a/pooltool/layouts.py
+++ b/pooltool/layouts.py
@@ -373,7 +373,7 @@ def _get_three_cushion_rack(
     if ballset is None:
         ballset = DEFAULT_THREECUSH_BALLSET
 
-    white = BallPos([], (0.62, 0.25), {"white"})
+    white = BallPos([], (0.5+0.1825/1.42, 0.25), {"white"})
     yellow = BallPos([], (0.5, 0.25), {"yellow"})
     red = BallPos([], (0.5, 0.75), {"red"})
 

--- a/pooltool/objects/table/specs.py
+++ b/pooltool/objects/table/specs.py
@@ -125,13 +125,10 @@ class BilliardTableSpecs:
         - See :class:`SnookerTableSpecs` for pocket table specs.
     """
 
-    # 10-foot table (imprecise)
-    l: float = field(default=3.05)  # noqa  E741
-    w: float = field(default=3.05 / 2)
-
-    cushion_width: float = field(default=2 * 2.54 / 100)
-
     # https://web.archive.org/web/20130801042614/http://www.umb.org/Rules/Carom_Rules.pdf
+    l: float = field(default=2.84)
+    w: float = field(default=1.42)
+    cushion_width: float = field(default=2 * 2.54 / 100)
     cushion_height: float = field(default=0.037)
 
     # For visualization


### PR DESCRIPTION
Correct 3C table dimensions in `pooltool/objects/table/specs.py` in lines 129, 130
Correct start position of white ball in `pooltool/layouts.py` line 376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Refined the ball arrangement in a key game layout to deliver a more balanced setup.
  - Updated table dimensions to enhance realism and provide a more authentic playing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->