### PR TITLE
Fix invalid quadratic roots in ball_linear_cushion_collision_time

### DIFF
--- a/pooltool/evolution/event_based/solve.py
+++ b/pooltool/evolution/event_based/solve.py
@@ -1,4 +1,4 @@
-from math import acos
+from math import acos, isnan
 from typing import Tuple
 
 import numpy as np
@@ -247,6 +247,9 @@ def ball_linear_cushion_collision_time(
 
     min_time = np.inf
     for root in roots:
+        if isnan(root):
+            continue
+
         if np.abs(root.imag) > const.EPS:
             continue
 

--- a/pooltool/ptmath/roots/quadratic.py
+++ b/pooltool/ptmath/roots/quadratic.py
@@ -1,3 +1,4 @@
+import math
 from typing import Tuple
 
 import numpy as np
@@ -10,6 +11,8 @@ import pooltool.constants as const
 def solve(a: float, b: float, c: float) -> Tuple[float, float]:
     """Solve a quadratic equation At^2 + Bt + C = 0 (just-in-time compiled)"""
     if np.abs(a) < const.EPS:
+        if np.abs(b) < const.EPS:
+            return math.nan, math.nan
         u = -c / b
         return u, u
     bp = b / 2


### PR DESCRIPTION
Shots that are parallel to the rail have A=0 and B=0, which would cause division by zero quadratic.solve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved numerical robustness by filtering out invalid values during complex calculations.
	- Enhanced equation handling to safely return undefined outputs when inputs are insufficient for a valid solution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->