### PR TITLE
Parallel multisystem playback

### DIFF
--- a/pooltool/__init__.py
+++ b/pooltool/__init__.py
@@ -39,7 +39,7 @@ import pooltool.system as system
 import pooltool.terminal as terminal
 import pooltool.utils as utils
 from pooltool.events import EventType
-from pooltool.evolution import continuize, simulate
+from pooltool.evolution import continuize, interpolate_ball_states, simulate
 from pooltool.game.datatypes import GameType
 from pooltool.interact import Game, show
 from pooltool.layouts import generate_layout, get_rack
@@ -91,5 +91,6 @@ __all__ = [
     "get_ruleset",
     "simulate",
     "continuize",
+    "interpolate_ball_states",
     "generate_layout",
 ]

--- a/pooltool/ani/animate.py
+++ b/pooltool/ani/animate.py
@@ -164,6 +164,10 @@ class Interface(ShowBase):
         tasks.register_event("toggle-help", hud.toggle_help)
 
     def close_scene(self):
+        # Ensure parallel mode is exited
+        if visual.is_parallel_mode:
+            visual.exit_parallel_mode()
+
         visual.teardown()
 
         environment.unload_room()
@@ -366,7 +370,12 @@ class ShotViewer(Interface):
 
                 Note:
                     If a multisystem is passed, the systems can be scrolled through by
-                    pressing *n* (next) and *p* (previous).
+                    pressing *n* (next) and *p* (previous). When using ``pt.show()``,
+                    press *Enter* to toggle parallel visualization mode where all systems
+                    play simultaneously with reduced opacity except the active one. In
+                    parallel mode, use *n* and *p* to change which system has full opacity.
+                    Note that parallel visualization is only available in ``pt.show()``
+                    and not when playing the game through ``run-pooltool``.
             title:
                 The title to display in the visualization. Defaults to an empty string.
             camera_state:

--- a/pooltool/ani/modes/shot.py
+++ b/pooltool/ani/modes/shot.py
@@ -213,6 +213,7 @@ class ShotMode(BaseMode):
         elif self.keymap[Action.aim] or visual.animation_finished:
             # Either the user has requested to start the next shot, or the animation has
             # finished
+
             Global.mode_mgr.change_mode(Mode.aim, exit_kwargs=dict(key="advance"))
 
         elif self.keymap[Action.zoom]:

--- a/pooltool/evolution/__init__.py
+++ b/pooltool/evolution/__init__.py
@@ -1,9 +1,10 @@
 """Shot evolution algorithm routines"""
 
-from pooltool.evolution.continuize import continuize
+from pooltool.evolution.continuize import continuize, interpolate_ball_states
 from pooltool.evolution.event_based.simulate import simulate
 
 __all__ = [
     "continuize",
     "simulate",
+    "interpolate_ball_states",
 ]

--- a/pooltool/evolution/continuize.py
+++ b/pooltool/evolution/continuize.py
@@ -1,11 +1,16 @@
-"""Module for building a time-dense system trajectory
+"""Module for building a time-dense system trajectory and interpolating ball states
 
-For an explanation, see :func:`continuize`
+For an explanation, see :func:`continuize` and :func:`interpolate_ball_states`
 """
+
+from typing import List, Sequence, Union
+
+import numpy as np
+from numpy.typing import NDArray
 
 import pooltool.physics.evolve as evolve
 from pooltool.events import filter_ball
-from pooltool.objects.ball.datatypes import BallHistory, BallState
+from pooltool.objects.ball.datatypes import Ball, BallHistory, BallState
 from pooltool.system.datatypes import System
 
 
@@ -185,3 +190,114 @@ def continuize(system: System, dt: float = 0.01, inplace: bool = False) -> Syste
         ball.history_cts = history
 
     return system
+
+
+def interpolate_ball_states(
+    ball: Ball,
+    timestamps: Union[NDArray[np.float64], Sequence[float]],
+    *,
+    extrapolate: bool = False,
+) -> List[BallState]:
+    """Calculate exact ball states at arbitrary timestamps.
+
+    This function calculates the precise ball states at arbitrary timestamps by evolving
+    the ball from the nearest preceding event state using the same physics model as the
+    simulation. It provides physically accurate positions, velocities, and angular velocities
+    according to the ball's motion equations.
+
+    Args:
+        ball:
+            The Ball object containing the history and physical parameters.
+        timestamps:
+            A sequence or numpy array of timestamps at which to calculate ball states.
+            Should be in ascending order and within the history's time range.
+        extrapolate:
+            If True, timestamps outside the history's time range will use the nearest boundary
+            state (initial or final). If False (default), a ValueError is raised for timestamps
+            outside the range.
+
+    Returns:
+        A list of BallState objects corresponding to the given timestamps.
+
+    Raises:
+        ValueError:
+            If history is empty or if timestamps are out of range and extrapolate is False.
+
+    Examples:
+        >>> import pooltool as pt
+        >>> import numpy as np
+        >>> system = pt.simulate(pt.System.example())
+        >>> ball = system.balls["cue"]
+        >>> # Get ball states at specific timestamps
+        >>> timestamps = np.array([0.5, 1.0, 1.5])
+        >>> states = pt.interpolate_ball_states(ball, timestamps)
+        >>> # Use the states
+        >>> states[0].rvw[0]  # Position at t=0.5
+        array([x, y, z])
+    """
+    history = ball.history
+    params = ball.params
+
+    if history.empty:
+        raise ValueError("Cannot interpolate from empty history")
+
+    if not isinstance(timestamps, np.ndarray):
+        timestamps = np.array(timestamps, dtype=np.float64)
+
+    if not np.all(np.diff(timestamps) >= 0):
+        raise ValueError("Timestamps must be in ascending order")
+
+    min_time = history[0].t
+    max_time = history[-1].t
+
+    if not extrapolate and (timestamps[0] < min_time or timestamps[-1] > max_time):
+        raise ValueError(
+            f"Timestamps must be within history time range ({min_time}, {max_time})"
+        )
+
+    result_states = []
+    history_array = history.states
+    history_len = len(history_array)
+
+    idx = 0
+
+    for t in timestamps:
+        if t < min_time:
+            result_states.append(history_array[0].copy())
+            continue
+        elif t > max_time:
+            result_states.append(history_array[-1].copy())
+            continue
+
+        # Find the nearest preceding state in history
+        while idx < history_len - 1 and history_array[idx + 1].t <= t:
+            idx += 1
+
+        # Go back one step if we've advanced too far
+        if history_array[idx].t > t and idx > 0:
+            idx -= 1
+
+        # Get the reference state to evolve from
+        ref_state = history_array[idx]
+
+        if abs(ref_state.t - t) < 1e-10:
+            # The timestamp exactly matches a history state, use it directly
+            result_states.append(ref_state.copy())
+            continue
+
+        evolve_time = t - ref_state.t
+        rvw, s = evolve.evolve_ball_motion(
+            state=ref_state.s,
+            rvw=ref_state.rvw,
+            R=params.R,
+            m=params.m,
+            u_s=params.u_s,
+            u_sp=params.u_sp,
+            u_r=params.u_r,
+            g=params.g,
+            t=evolve_time,
+        )
+
+        result_states.append(BallState(rvw=rvw, s=s, t=t))
+
+    return result_states

--- a/pooltool/interact.py
+++ b/pooltool/interact.py
@@ -23,7 +23,12 @@ def show(*args, **kwargs):
 
             Note:
                 If a multisystem is passed, the systems can be scrolled through by
-                pressing *n* (next) and *p* (previous).
+                pressing *n* (next) and *p* (previous). When using ``pt.show()``,
+                press *Enter* to toggle parallel visualization mode where all systems
+                play simultaneously with reduced opacity except the active one. In
+                parallel mode, use *n* and *p* to change which system has full opacity.
+                Note that parallel visualization is only available in ``pt.show()``
+                and not when playing the game through ``run-pooltool``.
         title:
             The title to display in the visualization. Defaults to an empty string.
         camera_state:

--- a/pooltool/objects/ball/render.py
+++ b/pooltool/objects/ball/render.py
@@ -203,12 +203,11 @@ class BallRender(Render):
         ws = rvws[:, 2, :]
         self.quats = autils.as_quaternion(ws, ts)
 
-    def get_playback_sequence(self, playback_speed=1) -> MetaInterval:
+    def get_playback_sequence(self, playback_speed: float = 1.0) -> MetaInterval:
         """Creates the motion sequences of the ball for a given playback speed"""
-        if self._ball.history_cts.empty:
-            return Sequence()
-
         vectors = self._ball.history_cts.vectorize()
+        if vectors is None:
+            return Sequence()
 
         rvws, motion_states, ts = vectors
 

--- a/pooltool/objects/ball/render.py
+++ b/pooltool/objects/ball/render.py
@@ -205,9 +205,10 @@ class BallRender(Render):
 
     def get_playback_sequence(self, playback_speed: float = 1.0) -> MetaInterval:
         """Creates the motion sequences of the ball for a given playback speed"""
-        vectors = self._ball.history_cts.vectorize()
-        if vectors is None:
+        if self._ball.history_cts.empty:
             return Sequence()
+
+        vectors = self._ball.history_cts.vectorize()
 
         rvws, motion_states, ts = vectors
 

--- a/pooltool/system/render.py
+++ b/pooltool/system/render.py
@@ -149,9 +149,21 @@ class SystemController:
 
     def restart_animation(self) -> None:
         """Set the animation to t=0"""
+        # If animation is completed (in final state), clear it before setting time. This
+        # avoids stdout warnings from Panda3D like:
+        # :interval(warning): CLerpNodePathInterval::priv_step() called for LerpPosQuatInterval-1 in state final.
+        if not self.shot_animation.isPlaying() and not self.paused:
+            self.shot_animation.clearToInitial()
+
         self.shot_animation.set_t(0)
 
     def restart_ball_animations(self) -> None:
+        # If animation is completed (in final state), clear it before setting time. This
+        # avoids stdout warnings from Panda3D like:
+        # :interval(warning): CLerpNodePathInterval::priv_step() called for LerpPosQuatInterval-1 in state final.
+        if not self.ball_animations.isPlaying() and not self.paused:
+            self.ball_animations.clearToInitial()
+
         self.ball_animations.set_t(0)
 
     def toggle_pause(self) -> None:

--- a/pooltool/system/render.py
+++ b/pooltool/system/render.py
@@ -91,8 +91,12 @@ class SystemController:
         """Returns whether or not the animation is finished
 
         Returns true if the animation has stopped and it's not because the game has been
-        paused. The animation is never finished if it's playing in a loop.
+        paused. The animation is never finished if it's playing in a loop or in parallel mode.
         """
+        # Never consider animation finished in LOOP mode or in parallel mode
+        if self.playback_mode == PlaybackMode.LOOP or self.is_parallel_mode:
+            return False
+
         return not self.shot_animation.isPlaying() and not self.paused
 
     def buildup(self) -> None:
@@ -138,7 +142,8 @@ class SystemController:
         if mode is not None:
             self.playback(mode)
 
-        if self.playback_mode == PlaybackMode.LOOP:
+        # In parallel mode, always use LOOP behavior
+        if self.playback_mode == PlaybackMode.LOOP or self.is_parallel_mode:
             self.shot_animation.loop()
         elif self.playback_mode == PlaybackMode.SINGLE:
             self.shot_animation.start()

--- a/tests/evolution/test_continuize.py
+++ b/tests/evolution/test_continuize.py
@@ -1,4 +1,7 @@
-from pooltool.evolution.continuize import continuize
+import numpy as np
+import pytest
+
+from pooltool.evolution.continuize import continuize, interpolate_ball_states
 from pooltool.evolution.event_based.simulate import simulate
 from pooltool.system import System
 
@@ -30,3 +33,80 @@ def test_continuize_inplace():
 
     # They are the same object
     assert continuized_system is system
+
+
+def test_interpolate_ball_states_exact_match():
+    """Test interpolation at exact timestamps from history."""
+    # Simulate and continuize a system
+    system = simulate(System.example())
+    ball = system.balls["cue"]
+
+    # Pick specific timestamps from history
+    t0 = ball.history[3].t
+    t1 = ball.history[4].t
+    timestamps = np.array([t0, t1])
+
+    # Interpolate at those exact timestamps
+    states = interpolate_ball_states(ball, timestamps)
+
+    # Should match exactly
+    assert len(states) == 2
+    assert states[0] == ball.history[3]
+    assert states[1] == ball.history[4]
+
+
+def test_interpolate_ball_states_intermediate():
+    """Test interpolation at timestamps between history entries."""
+    system = simulate(System.example())
+    ball = system.balls["cue"]
+
+    # Pick a timestamp between two history entries
+    t0 = ball.history[0].t
+    t1 = ball.history[1].t
+    t_mid = (t0 + t1) / 2
+
+    # Interpolate at the midpoint
+    states = interpolate_ball_states(ball, [t_mid])
+
+    # Should be a valid state
+    assert states[0].t == t_mid
+
+
+def test_interpolate_ball_states_out_of_range():
+    """Test behavior when timestamps are outside the history range."""
+    # Simulate a system
+    system = simulate(System.example())
+    ball = system.balls["cue"]
+
+    # Timestamp before history starts
+    t_before = ball.history[0].t - 1.0
+
+    # Timestamp after history ends
+    t_after = ball.history[-1].t + 1.0
+
+    # Raises error when extrapolate is False
+    with pytest.raises(ValueError):
+        interpolate_ball_states(ball, [t_before])
+
+    with pytest.raises(ValueError):
+        interpolate_ball_states(ball, [t_after])
+
+    # Returns boundary states when extrapolate is True
+    before_states = interpolate_ball_states(ball, [t_before], extrapolate=True)
+    assert len(before_states) == 1
+    assert before_states[0] == ball.history[0]
+
+    after_states = interpolate_ball_states(ball, [t_after], extrapolate=True)
+    assert len(after_states) == 1
+    assert after_states[0] == ball.history[-1]
+
+
+def test_interpolate_ball_states_empty_history():
+    """Test behavior with empty history."""
+    # Create a ball with empty history
+    system = System.example()
+    ball = system.balls["cue"]
+
+    # Should raise error
+    with pytest.raises(ValueError, match="Cannot interpolate from empty history"):
+        interpolate_ball_states(ball, [0.5])


### PR DESCRIPTION
# Parallel multisystem playback

This let's you visualize different shots simultaneously. By pressing Enter when passing a multisystem to `show`. Press *n* and *p* to highlight the shot of interest. Press Enter to return to serial viewing (toggle through different shots with *n* and *p*).

```python
import numpy as np

import pooltool as pt

template = pt.System.example()
template.balls["cue"].state.rvw[0, 0] = 0.3
template.cue.set_state(a=0, b=0.4, phi=pt.aim.at_ball(template, "1") + 2.5)

systems = []
for V0 in np.linspace(1, 3, 20):
    system = template.copy()
    system.cue.set_state(V0=V0)
    pt.simulate(system, inplace=True)
    systems.append(system)

pt.show(pt.MultiSystem(systems))
```

![asdf](https://github.com/user-attachments/assets/60934b9d-58be-40f2-9bd2-9bd0031d849e)

What you're seeing is 20 different shots played at the same time.

# Drivebys:

* Added a function to find the state of a ball at any time point.

---------

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a parallel visualization mode that displays multiple systems side-by-side with synchronized animations and adjustable opacity. Users can toggle this mode with keyboard shortcuts for a more dynamic viewing experience.
  - Enhanced visual transitions during shot mode to ensure consistent behavior when entering or exiting parallel mode.

- **Documentation**
  - Updated interactive instructions detailing keyboard controls for toggling parallel mode and navigating between systems.

- **Bug Fixes**
  - Improved state management and error handling for smoother playback and visualization transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->