### PR TITLE
Fix structuring when history is empty

### DIFF
--- a/pooltool/objects/ball/datatypes.py
+++ b/pooltool/objects/ball/datatypes.py
@@ -308,7 +308,9 @@ class BallHistory:
 
 
 conversion.register_unstructure_hook(
-    BallHistory, lambda v: v.vectorize(), which=(SerializeFormat.MSGPACK,)
+    BallHistory,
+    lambda v: v.vectorize() if not v.empty else None,
+    which=(SerializeFormat.MSGPACK,),
 )
 conversion.register_structure_hook(
     BallHistory,

--- a/tests/objects/ball/test_datatypes.py
+++ b/tests/objects/ball/test_datatypes.py
@@ -12,6 +12,7 @@ from pooltool.objects.ball.datatypes import (
     _null_rvw,
 )
 from pooltool.objects.ball.sets import get_ballset
+from pooltool.serialize import SerializeFormat, conversion
 
 
 def test__null_rvw():
@@ -63,6 +64,23 @@ def test_ball_history_empty():
     empty_history = BallHistory()
     assert not len(empty_history)
     assert empty_history.empty
+
+
+def test_ball_history_empty_serialization():
+    """Test that an empty BallHistory can be serialized and deserialized."""
+    empty_history = BallHistory()
+
+    # Test both JSON and MSGPACK formats
+    for fmt in [SerializeFormat.JSON, SerializeFormat.MSGPACK]:
+        c = conversion[fmt]
+        # Serialize
+        serialized = c.unstructure(empty_history)
+        # Deserialize
+        deserialized = c.structure(serialized, BallHistory)
+
+        # Verify both are empty
+        assert deserialized.empty
+        assert empty_history == deserialized
 
 
 def test_ball_history_equality():


### PR DESCRIPTION
In https://github.com/ekiefl/pooltool/pull/200 I removed optional input for `vectorize`, which serialization was contingent upon for empty history cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved serialization of empty ball histories to prevent errors and ensure correct data handling.  
- **Tests**
  - Added tests to verify correct serialization and deserialization of empty ball histories across formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->