### PR TITLE
Remove cached property directive

### DIFF
--- a/docs/custom_directives.py
+++ b/docs/custom_directives.py
@@ -1,47 +1,8 @@
-from docutils import nodes
 from sphinx.util.docutils import SphinxDirective
 
-
-class CachedPropertyDirective(SphinxDirective):
-    required_arguments = 0
-    optional_arguments = 0
-    final_argument_whitespace = True
-    has_content = True
-
-    def run(self):
-        targetid = f"cached-property-{self.env.new_serialno('cached-property')}"
-        targetnode = nodes.target("", "", ids=[targetid])
-
-        # Create an admonition node to hold the content
-        admonition_node = nodes.admonition()
-
-        # Optional: Add a title to the admonition
-        title_text = "Cached Property Note"
-        admonition_node += nodes.title(title_text, title_text)
-
-        # Text before the hyperlink
-        pre_text = "This is a "
-        post_text = ", and should be accessed as an attribute, not as a method call."
-
-        # Creating the hyperlink
-        uri = (
-            "https://docs.python.org/3/library/functools.html#functools.cached_property"
-        )
-        link_text = "cached property"
-        hyperlink = nodes.reference("", "", nodes.Text(link_text), refuri=uri)
-
-        # Creating the paragraph and adding the intro text and hyperlink
-        para = nodes.paragraph("", "")
-        para += nodes.Text(pre_text, pre_text)
-        para += hyperlink
-        para += nodes.Text(post_text, post_text)
-
-        # Add the paragraph to the admonition
-        admonition_node += para
-
-        # Return the target node and the admonition node as the directive's output
-        return [targetnode, admonition_node]
+class PlaceholderDirective(SphinxDirective):
+    pass
 
 
 def setup(app):
-    app.add_directive("cached_property_note", CachedPropertyDirective)
+    app.add_directive("placeholder", PlaceholderDirective)

--- a/pooltool/objects/ball/params.py
+++ b/pooltool/objects/ball/params.py
@@ -81,11 +81,9 @@ class BallParams:
 
     @cached_property
     def u_sp(self) -> float:
-        """Coefficient of spinning friction
+        """Coefficient of spinning friction.
 
-        This is equal to :attr:`u_sp_proportionality` * :attr:`R`
-
-        .. cached_property_note::
+        This is equal to :attr:`u_sp_proportionality` * :attr:`R`.
         """
         return self.u_sp_proportionality * self.R
 

--- a/pooltool/objects/table/components.py
+++ b/pooltool/objects/table/components.py
@@ -87,17 +87,12 @@ class LinearCushionSegment:
 
     @cached_property
     def height(self) -> float:
-        """The height of the cushion
-
-        .. cached_property_note::
-        """
+        """The height of the cushion."""
         return self.p1[2]
 
     @cached_property
     def lx(self) -> float:
         """The x-coefficient (:math:`l_x`) of the cushion's 2D general form line equation.
-
-        .. cached_property_note::
 
         The cushion's general form line equation in the :math:`XY` plane (*i.e.*
         dismissing the z-component) is
@@ -125,8 +120,6 @@ class LinearCushionSegment:
         """The x-coefficient (:math:`l_y`) of the cushion's 2D general form line equation.
 
         See :meth:`lx` for definition.
-
-        .. cached_property_note::
         """
         return 0 if (self.p2[0] - self.p1[0]) == 0 else 1
 
@@ -135,8 +128,6 @@ class LinearCushionSegment:
         """The constant term (:math:`l_0`) of the cushion's 2D general form line equation.
 
         See :meth:`lx` for definition.
-
-        .. cached_property_note::
         """
         p1x, p1y, _ = self.p1
         p2x, p2y, _ = self.p2
@@ -262,26 +253,17 @@ class CircularCushionSegment:
 
     @cached_property
     def height(self) -> float:
-        """The height of the cushion
-
-        .. cached_property_note::
-        """
+        """The height of the cushion."""
         return self.center[2]
 
     @cached_property
     def a(self) -> float:
-        """The x-coordinate of the cushion's center
-
-        .. cached_property_note::
-        """
+        """The x-coordinate of the cushion's center."""
         return self.center[0]
 
     @cached_property
     def b(self) -> float:
-        """The y-coordinate of the cushion's center
-
-        .. cached_property_note::
-        """
+        """The y-coordinate of the cushion's center."""
         return self.center[1]
 
     def get_normal_xy(self, rvw: NDArray[np.float64]) -> NDArray[np.float64]:
@@ -412,18 +394,12 @@ class Pocket:
 
     @cached_property
     def a(self) -> float:
-        """The x-coordinate of the pocket's center
-
-        .. cached_property_note::
-        """
+        """The x-coordinate of the pocket's center."""
         return self.center[0]
 
     @cached_property
     def b(self) -> float:
-        """The y-coordinate of the pocket's center
-
-        .. cached_property_note::
-        """
+        """The y-coordinate of the pocket's center."""
         return self.center[1]
 
     def add(self, ball_id: str) -> None:


### PR DESCRIPTION
Someone somewhere made docs properly render functools' cached_property as a property rather than a method.