### PR TITLE
Add shot introspection to 3D branch

### DIFF
--- a/pooltool/events/datatypes.py
+++ b/pooltool/events/datatypes.py
@@ -259,14 +259,15 @@ def _disambiguate_agent_structuring(
     id = con.structure(uo["id"], str)
     agent_type = con.structure(uo["agent_type"], AgentType)
 
-    # All agents but the NULL agent have initial states
-    if agent_type == AgentType.NULL:
+    # NULL agents always have None initial. Other agents may have None initial if
+    # they are unresolved (e.g., events in caches before resolution)
+    if agent_type == AgentType.NULL or uo["initial"] is None:
         initial = None
     else:
         initial = con.structure(uo["initial"], _type_to_class[agent_type])
 
     # Only BALL and POCKET have final states
-    if agent_type in (AgentType.BALL, AgentType.POCKET):
+    if agent_type in (AgentType.BALL, AgentType.POCKET) and uo["final"] is not None:
         final = con.structure(uo["final"], _type_to_class[agent_type])
     else:
         final = None

--- a/pooltool/evolution/event_based/cache.py
+++ b/pooltool/evolution/event_based/cache.py
@@ -19,6 +19,7 @@ from pooltool.events import (
 )
 from pooltool.events.utils import event_type_to_ball_indices
 from pooltool.objects.ball.datatypes import Ball
+from pooltool.serialize import SerializeFormat, conversion
 from pooltool.system.datatypes import System
 
 
@@ -48,6 +49,11 @@ class TransitionCache:
     def get_next(self) -> Event:
         return min(
             (trans for trans in self.transitions.values()), key=lambda event: event.time
+        )
+
+    def copy(self) -> TransitionCache:
+        return TransitionCache(
+            transitions={k: v.copy() for k, v in self.transitions.items()}
         )
 
     def update(self, event: Event) -> None:
@@ -129,11 +135,14 @@ class CollisionCache:
           event caching, see :class:`TransitionCache`.
     """
 
-    times: dict[EventType, dict[tuple[str, str], float]] = attrs.field(factory=dict)
+    times: dict[EventType, dict[tuple[str, ...], float]] = attrs.field(factory=dict)
 
     @property
     def size(self) -> int:
         return sum(len(cache) for cache in self.times.values())
+
+    def copy(self) -> CollisionCache:
+        return CollisionCache(times={k: v.copy() for k, v in self.times.items()})
 
     def _get_invalid_ball_ids(self, event: Event) -> set[str]:
         return {
@@ -161,3 +170,36 @@ class CollisionCache:
     @classmethod
     def create(cls) -> CollisionCache:
         return cls()
+
+
+def _unstructure_collision_cache(cache: CollisionCache) -> dict:
+    return {
+        "times": {
+            event_type: {"|".join(key): value for key, value in event_times.items()}
+            for event_type, event_times in cache.times.items()
+        }
+    }
+
+
+def _structure_collision_cache(data: dict, _: type) -> CollisionCache:
+    return CollisionCache(
+        times={
+            event_type: {
+                tuple(key.split("|")): value for key, value in event_times.items()
+            }
+            for event_type, event_times in data["times"].items()
+        }
+    )
+
+
+conversion.register_unstructure_hook(
+    CollisionCache,
+    _unstructure_collision_cache,
+    which=(SerializeFormat.JSON,),
+)
+
+conversion.register_structure_hook(
+    CollisionCache,
+    _structure_collision_cache,
+    which=(SerializeFormat.JSON,),
+)

--- a/pooltool/evolution/event_based/introspection.py
+++ b/pooltool/evolution/event_based/introspection.py
@@ -1,0 +1,256 @@
+#! /usr/bin/env python
+"""Event-based simulation introspection tools.
+
+This module provides utilities for capturing and analyzing simulation state at each
+step of event-based pool simulations. It enables detailed inspection of system states,
+events, and collision caches throughout simulation execution.
+
+The primary use case is debugging and understanding simulation behavior by examining:
+- System state before evolution (pre_evolve)
+- System state after time evolution but before collision resolution (post_evolve)
+- System state after collision resolution (post_resolve)
+- All prospective events considered at each step
+- Collision and transition caches at each step
+
+Key components:
+    SimulationSnapshot: Captures complete state at a single simulation step
+    SimulationSnapshotSequence: Collection of snapshots across entire simulation
+    simulate_with_snapshots: Runs simulation while capturing snapshots
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import attrs
+
+from pooltool.events import (
+    Event,
+    EventType,
+    ball_ball_collision,
+    ball_circular_cushion_collision,
+    ball_linear_cushion_collision,
+    ball_pocket_collision,
+    stick_ball_collision,
+)
+from pooltool.evolution.event_based.cache import CollisionCache, TransitionCache
+from pooltool.evolution.event_based.config import INCLUDED_EVENTS
+from pooltool.evolution.event_based.simulate import (
+    DEFAULT_ENGINE,
+    _SimulationState,
+)
+from pooltool.physics.engine import PhysicsEngine
+from pooltool.ptmath.roots.quartic import QuarticSolver
+from pooltool.serialize import conversion
+from pooltool.serialize.serializers import Pathish
+from pooltool.system.datatypes import System
+
+
+def _get_collision_events_from_cache(
+    system: System, cache: CollisionCache
+) -> list[Event]:
+    events = []
+
+    if EventType.BALL_BALL in cache.times:
+        for (ball1_id, ball2_id), time in cache.times[EventType.BALL_BALL].items():
+            events.append(
+                ball_ball_collision(
+                    ball1=system.balls[ball1_id],
+                    ball2=system.balls[ball2_id],
+                    time=time,
+                )
+            )
+
+    if EventType.BALL_LINEAR_CUSHION in cache.times:
+        for (ball_id, cushion_id), time in cache.times[
+            EventType.BALL_LINEAR_CUSHION
+        ].items():
+            events.append(
+                ball_linear_cushion_collision(
+                    ball=system.balls[ball_id],
+                    cushion=system.table.cushion_segments.linear[cushion_id],
+                    time=time,
+                )
+            )
+
+    if EventType.BALL_CIRCULAR_CUSHION in cache.times:
+        for (ball_id, cushion_id), time in cache.times[
+            EventType.BALL_CIRCULAR_CUSHION
+        ].items():
+            events.append(
+                ball_circular_cushion_collision(
+                    ball=system.balls[ball_id],
+                    cushion=system.table.cushion_segments.circular[cushion_id],
+                    time=time,
+                )
+            )
+
+    if EventType.BALL_POCKET in cache.times:
+        for (ball_id, pocket_id), time in cache.times[EventType.BALL_POCKET].items():
+            events.append(
+                ball_pocket_collision(
+                    ball=system.balls[ball_id],
+                    pocket=system.table.pockets[pocket_id],
+                    time=time,
+                )
+            )
+
+    if EventType.STICK_BALL in cache.times:
+        for (cue_id, ball_id), time in cache.times[EventType.STICK_BALL].items():
+            events.append(
+                stick_ball_collision(
+                    stick=system.cue,
+                    ball=system.balls[ball_id],
+                    time=time,
+                )
+            )
+
+    return events
+
+
+@attrs.define
+class SimulationSnapshot:
+    step_number: int
+    system: System
+    selected_event: Event
+    collision_cache: CollisionCache
+    transition_cache: TransitionCache
+    engine: PhysicsEngine
+
+    def get_prospective_events(self) -> list[Event]:
+        """Get all prospective events.
+
+        Returns all cached collision and transition events that were possible at the
+        given step, sorted by time. These events are "prospective" - they have been
+        detected but not yet resolved, so their agents' initial and final states are
+        None.
+
+        A prospective event becomes resolved when it is selected as the next event to
+        occur and the physics engine processes it via resolver.resolve(), which sets
+        the initial and final states of the agents involved.
+
+        Args:
+            step: The simulation step index
+
+        Returns:
+            A list of prospective events sorted by time
+        """
+        system = self.system
+        cache = self.collision_cache
+        transition_cache = self.transition_cache
+
+        events = _get_collision_events_from_cache(system, cache)
+
+        for event in transition_cache.transitions.values():
+            events.append(event)
+
+        return sorted(events, key=lambda e: e.time)
+
+    def pre_evolve_system(self) -> System:
+        """Returns a copy of the system state"""
+        return self.system.copy()
+
+    def post_evolve_system(self, event: Event) -> System:
+        system = self.pre_evolve_system()
+        dt = event.time - system.t
+        _SimulationState.evolve(system, dt)
+        system.t += dt
+        return system
+
+    def post_resolve_system(self, event: Event) -> System:
+        system = self.post_evolve_system(event)
+        self.engine.resolver.resolve(system, event)
+        system._update_history(event)
+        return system
+
+
+@attrs.define
+class SimulationSnapshotSequence:
+    steps: list[SimulationSnapshot] = attrs.field(factory=list)
+    engine: PhysicsEngine = attrs.field(factory=PhysicsEngine)
+
+    def add(self, snapshot: SimulationSnapshot) -> None:
+        self.steps.append(snapshot)
+
+    def __len__(self) -> int:
+        return len(self.steps)
+
+    def __getitem__(self, index: int) -> SimulationSnapshot:
+        return self.steps[index]
+
+    def save(self, path: Pathish) -> Path:
+        path = Path(path)
+        conversion.unstructure_to(self, path)
+        return path
+
+    @classmethod
+    def load(cls, path: Pathish) -> SimulationSnapshotSequence:
+        return conversion.structure_from(path, cls)
+
+
+def simulate_with_snapshots(
+    shot: System,
+    output_path: Path | None = None,
+    engine: PhysicsEngine | None = None,
+    t_final: float | None = None,
+    quartic_solver: QuarticSolver = QuarticSolver.HYBRID,
+    include: set[EventType] = INCLUDED_EVENTS,
+    max_events: int = 0,
+) -> tuple[System, SimulationSnapshotSequence]:
+    if not engine:
+        engine = DEFAULT_ENGINE
+
+    sim = _SimulationState(
+        shot.copy(),
+        engine,
+        t_final,
+        quartic_solver,
+        include,
+        max_events,
+    )
+    sim.init()
+
+    snapshot_sequence = SimulationSnapshotSequence(engine=engine)
+
+    step = 0
+    while not sim.done:
+        system_pre_evolve = sim.shot.copy()
+
+        event = sim.step()
+
+        # Capture the cache states when they have all possible event times for the
+        # pre-evolve shot.
+        collision_cache_snapshot = sim.collision_cache.copy()
+        transition_cache_snapshot = sim.transition_cache.copy()
+
+        if not sim.done:
+            # Update the caches to be accurate for the next iteration.
+            sim.update_caches(event)
+
+        snapshot = SimulationSnapshot(
+            step_number=step,
+            system=system_pre_evolve,
+            selected_event=event,
+            collision_cache=collision_cache_snapshot,
+            transition_cache=transition_cache_snapshot,
+            engine=engine,
+        )
+
+        snapshot_sequence.add(snapshot)
+        if output_path is not None:
+            snapshot_sequence.save(output_path)
+
+        step += 1
+
+    return sim.shot, snapshot_sequence
+
+
+if __name__ == "__main__":
+    from pathlib import Path
+
+    import pooltool as pt
+
+    output = Path("test.json")
+    simulate_with_snapshots(pt.System.example(), output)
+    seq = SimulationSnapshotSequence.load(output)
+    system = pt.simulate(pt.System.example())

--- a/pooltool/evolution/event_based/simulate.py
+++ b/pooltool/evolution/event_based/simulate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from itertools import combinations
 
+import attrs
 import numpy as np
 
 import pooltool.constants as const
@@ -39,40 +40,107 @@ from pooltool.system.datatypes import System
 DEFAULT_ENGINE = PhysicsEngine()
 
 
-def _get_system_energy(system: System) -> float:
-    """Calculate the energy of the system in Joules."""
-    return sum(
+def _system_has_energy(system: System) -> bool:
+    """Check whether the system has any positive energy.
+
+    Notes:
+        - Returns False as soon as first energetic ball is iterated through.
+        - Cue energy (e.g. setting system.cue.V0 > 0 doesn't count as energy).
+    """
+    return any(
         physics.get_ball_energy(
             ball.state.rvw,
             ball.params.R,
             ball.params.m,
             ball.params.g,
         )
+        > 0.0
         for ball in system.balls.values()
     )
 
 
-def _evolve(shot: System, dt: float):
-    """Evolves current ball an amount of time dt
+@attrs.define
+class _SimulationState:
+    shot: System
+    engine: PhysicsEngine
 
-    FIXME This is very inefficent. each ball should store its natural trajectory
-    thereby avoid a call to the clunky evolve_ball_motion. It could even be a
-    partial function so parameters don't continuously need to be passed
-    """
+    t_final: float | None = None
+    quartic_solver: QuarticSolver = QuarticSolver.HYBRID
+    include: set[EventType] = INCLUDED_EVENTS
+    max_events: int = 0
 
-    for ball in shot.balls.values():
-        rvw = evolve.evolve_ball_motion(
-            state=ball.state.s,
-            rvw=ball.state.rvw,
-            R=ball.params.R,
-            m=ball.params.m,
-            u_s=ball.params.u_s,
-            u_sp=ball.params.u_sp,
-            u_r=ball.params.u_r,
-            g=ball.params.g,
-            t=dt,
+    done: bool = attrs.field(init=False, default=False)
+    num_events: int = attrs.field(init=False, default=0)
+    collision_cache: CollisionCache = attrs.field(init=False)
+    transition_cache: TransitionCache = attrs.field(init=False)
+
+    def __attrs_post_init__(self) -> None:
+        self.collision_cache = CollisionCache.create()
+        self.transition_cache = TransitionCache.create(self.shot)
+
+    def init(self) -> None:
+        self.shot.reset_history()
+        self.shot._update_history(null_event(time=0))
+
+    def step(self) -> Event:
+        event = get_next_event(
+            self.shot,
+            transition_cache=self.transition_cache,
+            collision_cache=self.collision_cache,
+            quartic_solver=self.quartic_solver,
         )
-        ball.state = BallState(rvw, ball.state.s, shot.t + dt)
+
+        if event.time == np.inf:
+            self.shot._update_history(null_event(time=self.shot.t))
+            self.done = True
+            return event
+
+        self.evolve(self.shot, event.time - self.shot.t)
+
+        if event.event_type in self.include:
+            self.engine.resolver.resolve(self.shot, event)
+
+        self.shot._update_history(event)
+
+        if self.t_final is not None and self.shot.t >= self.t_final:
+            self.shot._update_history(null_event(time=self.shot.t))
+            self.done = True
+
+        if self.max_events > 0 and self.num_events > self.max_events:
+            self.shot.stop_balls()
+            self.done = True
+
+        self.num_events += 1
+
+        return event
+
+    def update_caches(self, event: Event) -> None:
+        if event.event_type in self.include:
+            self.transition_cache.update(event)
+            self.collision_cache.invalidate(event)
+
+    @staticmethod
+    def evolve(shot: System, dt: float):
+        """Evolves system an amount of time dt.
+
+        FIXME This is very inefficent. each ball should store its natural trajectory
+        thereby avoid a call to the clunky evolve_ball_motion. It could even be a
+        partial function so parameters don't continuously need to be passed
+        """
+
+        for ball in shot.balls.values():
+            rvw = evolve.evolve_ball_motion(
+                state=ball.state.s,
+                rvw=ball.state.rvw,
+                R=ball.params.R,
+                m=ball.params.m,
+                u_s=ball.params.u_s,
+                u_sp=ball.params.u_sp,
+                u_r=ball.params.u_r,
+                g=ball.params.g,
+                t=dt,
+            )
+            ball.state = BallState(rvw, ball.state.s, shot.t + dt)
 
 
 def simulate(
@@ -170,60 +238,18 @@ def simulate(
     if not engine:
         engine = DEFAULT_ENGINE
 
-    shot.reset_history()
-    shot._update_history(null_event(time=0.0))
+    sim = _SimulationState(shot, engine, t_final, quartic_solver, include, max_events)
+    sim.init()
 
-    if _get_system_energy(shot) == 0 and shot.cue.V0 > 0:
-        # System has no energy, but the cue stick has an impact velocity. So create and
-        # resolve a stick-ball collision to start things off
-        event = stick_ball_collision(
-            stick=shot.cue,
-            ball=shot.balls[shot.cue.cue_ball_id],
-            time=0.0,
-            set_initial=True,
-        )
-        engine.resolver.resolve(shot, event)
-        shot._update_history(event)
-
-    collision_cache = CollisionCache.create()
-    transition_cache = TransitionCache.create(shot)
-
-    events = 0
-    while True:
-        event = get_next_event(
-            shot,
-            transition_cache=transition_cache,
-            collision_cache=collision_cache,
-            quartic_solver=quartic_solver,
-        )
-
-        if event.time == np.inf:
-            shot._update_history(null_event(time=shot.t))
-            break
-
-        _evolve(shot, event.time - shot.t)
-
-        if event.event_type in include:
-            engine.resolver.resolve(shot, event)
-            transition_cache.update(event)
-            collision_cache.invalidate(event)
-
-        shot._update_history(event)
-
-        if t_final is not None and shot.t >= t_final:
-            shot._update_history(null_event(time=shot.t))
-            break
-
-        if max_events > 0 and events > max_events:
-            shot.stop_balls()
-            break
-
-        events += 1
+    while not sim.done:
+        event = sim.step()
+        if not sim.done:
+            sim.update_caches(event)
 
     if continuous:
-        continuize(shot, dt=0.01 if dt is None else dt, inplace=True)
+        continuize(sim.shot, dt=0.01 if dt is None else dt, inplace=True)
 
-    return shot
+    return sim.shot
 
 
 def get_next_event(
@@ -233,14 +259,28 @@ def get_next_event(
     collision_cache: CollisionCache | None = None,
     quartic_solver: QuarticSolver = QuarticSolver.HYBRID,
 ) -> Event:
+    # If not passed, unpopulated caches are initialized to pass to delegate functions.
+    # These empty caches will be populated by the delegate functions, but then thrown
+    # away when this function returns.
+    if transition_cache is None:
+        transition_cache = TransitionCache.create(shot)
+    if collision_cache is None:
+        collision_cache = CollisionCache.create()
+
     # Start by assuming next event doesn't happen
     event = null_event(time=np.inf)
 
-    if transition_cache is None:
-        transition_cache = TransitionCache.create(shot)
-
-    if collision_cache is None:
-        collision_cache = CollisionCache.create()
+    # Stick-ball collisions only occur at t=0 (shot initiation), so we skip this
+    # check after the first timestep as an optimization. Other collision types are
+    # always checked because they can occur at any time during simulation. Note: even
+    # at t=0, we still call the remaining detection functions to fully populate the
+    # collision cache, which is needed by debug/introspection tools.
+    if shot.t == 0:
+        stick_ball_event = get_next_stick_ball_collision(
+            shot, collision_cache=collision_cache
+        )
+        if stick_ball_event.time < event.time:
+            event = stick_ball_event
 
     transition_event = transition_cache.get_next()
     if transition_event.time < event.time:
@@ -277,6 +317,34 @@ def get_next_event(
         event = ball_pocket_event
 
     return event
+
+
+def get_next_stick_ball_collision(
+    shot: System, collision_cache: CollisionCache
+) -> Event:
+    """Returns next stick-ball collision"""
+
+    cache = collision_cache.times.setdefault(EventType.STICK_BALL, {})
+
+    obj_ids = (shot.cue.id, shot.cue.cue_ball_id)
+
+    if obj_ids in cache:
+        return stick_ball_collision(
+            stick=shot.cue,
+            ball=shot.balls[shot.cue.cue_ball_id],
+            time=cache[obj_ids],
+        )
+
+    if shot.t == 0 and not _system_has_energy(shot) and shot.cue.V0 > 0:
+        cache[obj_ids] = 0.0
+    else:
+        cache[obj_ids] = np.inf
+
+    return stick_ball_collision(
+        stick=shot.cue,
+        ball=shot.balls[shot.cue.cue_ball_id],
+        time=cache[obj_ids],
+    )
 
 
 def get_next_ball_ball_collision(

--- a/pooltool/physics/__init__.py
+++ b/pooltool/physics/__init__.py
@@ -3,10 +3,6 @@
 from pooltool.physics.engine import PhysicsEngine
 from pooltool.physics.evolve import (
     evolve_ball_motion,
-    evolve_perpendicular_spin_component,
-    evolve_perpendicular_spin_state,
-    evolve_roll_state,
-    evolve_slide_state,
 )
 from pooltool.physics.resolve import display_models
 from pooltool.physics.resolve.ball_ball import (
@@ -80,8 +76,4 @@ __all__ = [
     "ball_transition_models",
     # Evolve
     "evolve_ball_motion",
-    "evolve_slide_state",
-    "evolve_roll_state",
-    "evolve_perpendicular_spin_component",
-    "evolve_perpendicular_spin_state",
 ]

--- a/pooltool/physics/resolve/ball_table/frictional_inelastic/__init__.py
+++ b/pooltool/physics/resolve/ball_table/frictional_inelastic/__init__.py
@@ -43,6 +43,9 @@ def _resolve_ball_table(
     if has_relative_velocity:
         v_hat_c_i = ptmath.unit_vector(v_c_i)
         D_v_parallel_slip = u * D_v_perpendicular_magnitude * -v_hat_c_i
+    else:
+        v_hat_c_i = np.zeros(3)
+        D_v_parallel_slip = np.zeros(3)
 
     D_v_parallel_no_slip = (2.0 / 7.0) * (R * ptmath.cross(w_i, unit_z) - v_i)
 

--- a/pooltool/physics/utils.py
+++ b/pooltool/physics/utils.py
@@ -105,7 +105,8 @@ def get_ball_energy(rvw: NDArray[np.float64], R: float, m: float, g: float) -> f
     """Get the energy of a ball
 
     Accounts for linear and rotational kinetic energy and potential energy due to
-    gravity relative to a ball in contact with the table.
+    gravity relative to a ball in contact with the table. 0 potential energy is defined
+    as z=R.
     """
     # Linear
     LKE = m * norm3d(rvw[1]) ** 2 / 2

--- a/tests/evolution/event_based/test_introspection.py
+++ b/tests/evolution/event_based/test_introspection.py
@@ -1,0 +1,103 @@
+import tempfile
+from pathlib import Path
+
+import pooltool as pt
+from pooltool.evolution.event_based.introspection import (
+    SimulationSnapshotSequence,
+    simulate_with_snapshots,
+)
+from pooltool.evolution.event_based.simulate import simulate
+
+
+def test_simulate_with_snapshots_equivalence_with_simulate():
+    """Tests that `simulates_with_snapshots` returns same thing as `simulate`."""
+    system = pt.System.example()
+    result, _ = simulate_with_snapshots(system)
+    assert result == simulate(system)
+
+
+def test_snapshot_sequence_roundtrip():
+    system = pt.System.example()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _, seq = simulate_with_snapshots(system)
+        output = Path(tmpdir) / "seq.json"
+        seq.save(output)
+        assert seq == SimulationSnapshotSequence.load(output)
+
+
+def test_selected_event_in_all_possible_events():
+    system = pt.System.example()
+    _, seq = simulate_with_snapshots(system)
+
+    for step in range(len(seq) - 1):
+        snapshot = seq[step]
+        all_events = snapshot.get_prospective_events()
+        first_event = all_events[0]
+
+        assert snapshot.selected_event.event_type == first_event.event_type
+        assert snapshot.selected_event.time == first_event.time
+
+
+def test_pre_evolve_equals_snapshot_system():
+    """pre_evolve_system should return the same system as stored in snapshot."""
+    system = pt.System.example()
+    _, seq = simulate_with_snapshots(system)
+
+    for step in range(len(seq)):
+        snapshot = seq[step]
+        pre_evolve = snapshot.pre_evolve_system()
+
+        assert pre_evolve == snapshot.system
+        assert pre_evolve is not snapshot.system
+
+
+def test_post_evolve_advances_time():
+    """post_evolve_system should advance time to the selected event."""
+    system = pt.System.example()
+    _, seq = simulate_with_snapshots(system)
+
+    for step in range(len(seq)):
+        snapshot = seq[step]
+        event = snapshot.selected_event
+        post_evolve = snapshot.post_evolve_system(event)
+
+        assert post_evolve.t == event.time
+
+
+def test_post_resolve_of_n_equals_pre_evolve_of_n_plus_1():
+    """post_resolve_system of step n should equal pre_evolve_system of step n+1."""
+    system = pt.System.example()
+    _, seq = simulate_with_snapshots(system)
+
+    for step in range(len(seq) - 1):
+        current_snapshot = seq[step]
+        next_snapshot = seq[step + 1]
+
+        post_resolve = current_snapshot.post_resolve_system(
+            current_snapshot.selected_event
+        )
+        pre_evolve_next = next_snapshot.pre_evolve_system()
+
+        assert post_resolve == pre_evolve_next
+
+
+def test_system_state_progression():
+    """Test the full progression: pre_evolve -> post_evolve -> post_resolve."""
+    system = pt.System.example()
+    _, seq = simulate_with_snapshots(system)
+
+    for step in range(len(seq)):
+        snapshot = seq[step]
+        event = snapshot.selected_event
+
+        pre_evolve = snapshot.pre_evolve_system()
+        post_evolve = snapshot.post_evolve_system(event)
+        post_resolve = snapshot.post_resolve_system(event)
+
+        assert pre_evolve.t <= post_evolve.t
+        assert post_evolve.t == event.time
+        assert post_resolve.t == event.time
+
+        assert pre_evolve is not post_evolve
+        assert post_evolve is not post_resolve

--- a/tests/physics/evolve/test_airborne.py
+++ b/tests/physics/evolve/test_airborne.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from pooltool.physics.evolve import evolve_airborne_state
+from pooltool.physics.evolve import _evolve_airborne_state
 
 
 def test_xy_velocity_conserved():
@@ -13,7 +13,7 @@ def test_xy_velocity_conserved():
     g = 9.81
     t = 1.0
 
-    rvw = evolve_airborne_state(rvw0.copy(), g, t)
+    rvw = _evolve_airborne_state(rvw0.copy(), g, t)
 
     # Check if vx and vy are unchanged
     np.testing.assert_almost_equal(
@@ -34,7 +34,7 @@ def test_angular_velocity_conserved():
     g = 9.81
     t = 2.0
 
-    rvw = evolve_airborne_state(rvw0.copy(), g, t)
+    rvw = _evolve_airborne_state(rvw0.copy(), g, t)
 
     # Check if angular velocity is unchanged
     np.testing.assert_array_almost_equal(
@@ -59,7 +59,7 @@ def test_xy_displacement_linear():
     g = 9.81
 
     for t in [0.0, 1.0, 2.0, 3.0]:
-        rvw = evolve_airborne_state(rvw0.copy(), g, t)
+        rvw = _evolve_airborne_state(rvw0.copy(), g, t)
         expected_x = r0[0] + v0[0] * t
         expected_y = r0[1] + v0[1] * t
         np.testing.assert_almost_equal(
@@ -85,7 +85,7 @@ def test_gravity_direction():
     g = 9.81
     t = 1.0
 
-    rvw_t = evolve_airborne_state(rvw.copy(), g, t)
+    rvw_t = _evolve_airborne_state(rvw.copy(), g, t)
     expected_z = r0[2] + v0[2] * t - 0.5 * g * t**2
     expected_vz = v0[2] - g * t
 
@@ -115,7 +115,7 @@ def test_z_displacement_parabolic():
     z_values = []
 
     for t in times:
-        rvw_t = evolve_airborne_state(rvw.copy(), g, t)
+        rvw_t = _evolve_airborne_state(rvw.copy(), g, t)
         z_values.append(rvw_t[0, 2])
 
     z_values = np.array(z_values)


### PR DESCRIPTION
Merges https://github.com/ekiefl/pooltool/pull/232 into the 3D branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event-based introspection module enabling capture and inspection of simulation step-by-step details via new SimulationSnapshot and SimulationSnapshotSequence classes.
  * Added simulate_with_snapshots() function to run simulations while recording detailed snapshots.

* **Changes**
  * Physics API: evolve_slide_state, evolve_roll_state, evolve_perpendicular_spin_component, and evolve_perpendicular_spin_state are now private.

* **Bug Fixes**
  * Improved null initial state handling for event agents.
  * Fixed undefined variables in ball-table collision calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->