### PR TITLE
Revert PR #242 to Fix Tests

### DIFF
--- a/pooltool/physics/resolve/ball_cushion/impulse_frictional_inelastic/model.py
+++ b/pooltool/physics/resolve/ball_cushion/impulse_frictional_inelastic/model.py
@@ -19,7 +19,7 @@ from pooltool.physics.resolve.sphere_half_space_collision import (
 
 def _solve(ball: Ball, cushion: Cushion) -> tuple[Ball, Cushion]:
     rvw = resolve_sphere_half_space_collision(
-        normal=cushion.get_normal_xy(ball.xyz),
+        normal=cushion.get_normal_3d(ball.xyz),
         rvw=ball.state.rvw,
         R=ball.params.R,
         mu_k=ball.params.f_c,


### PR DESCRIPTION
Revert "switch ball_cushion/impulse_frictional_inelastic to use xy normal instead of 3d normal to match other models (#242)"

This reverts commit cd36015d982c69d8d6e956b5a69aa18942296801.