### PR TITLE
Multisize Ball-Ball Collision

### DIFF
--- a/pooltool/physics/resolve/ball_ball/frictional_inelastic/__init__.py
+++ b/pooltool/physics/resolve/ball_ball/frictional_inelastic/__init__.py
@@ -14,7 +14,7 @@ from pooltool.physics.resolve.models import BallBallModel
 
 
 @jit(nopython=True, cache=const.use_numba_cache)
-def _resolve_ball_ball(rvw1, rvw2, R, u_b, e_b):
+def _resolve_ball_ball(rvw1, m1, R1, rvw2, m2, R2, u_b, e_b):
     unit_x = np.array([1.0, 0.0, 0.0])
 
     # rotate the x-axis to be in line with the line of centers
@@ -27,9 +27,11 @@ def _resolve_ball_ball(rvw1, rvw2, R, u_b, e_b):
     rvw2[2] = ptmath.coordinate_rotation(rvw2[2], -theta)
 
     # velocity normal component, same for both slip and no-slip after collison cases
-    v1_n_f = 0.5 * ((1.0 - e_b) * rvw1[1][0] + (1.0 + e_b) * rvw2[1][0])
-    v2_n_f = 0.5 * ((1.0 + e_b) * rvw1[1][0] + (1.0 - e_b) * rvw2[1][0])
-    D_v_n_magnitude = abs(v2_n_f - v1_n_f)
+    v_12_n = rvw1[1][0] - rvw2[1][0]
+    D_v1_n = -(1 + e_b) / (1 + m1 / m2) * v_12_n
+    D_v2_n = -(m1 / m2) * D_v1_n
+    v1_n_f = rvw1[1][0] + D_v1_n
+    v2_n_f = rvw2[1][0] + D_v2_n
 
     # angular velocity normal component, unchanged
     w1_n_f = rvw1[2][0]
@@ -43,8 +45,8 @@ def _resolve_ball_ball(rvw1, rvw2, R, u_b, e_b):
     rvw1_f = rvw1.copy()
     rvw2_f = rvw2.copy()
 
-    v1_c = ptmath.surface_velocity(rvw1, unit_x, R)
-    v2_c = ptmath.surface_velocity(rvw2, -unit_x, R)
+    v1_c = ptmath.surface_velocity(rvw1, unit_x, R1)
+    v2_c = ptmath.surface_velocity(rvw2, -unit_x, R2)
     v12_c = v1_c - v2_c
     has_relative_velocity = ptmath.norm3d(v12_c) > const.EPS
 
@@ -53,28 +55,28 @@ def _resolve_ball_ball(rvw1, rvw2, R, u_b, e_b):
     if has_relative_velocity:
         # tangent components for slip condition
         v12_c_hat = ptmath.unit_vector(v12_c)
-        D_v1_t = u_b * D_v_n_magnitude * -v12_c_hat
-        D_w1 = 2.5 / R * ptmath.cross(unit_x, D_v1_t)
+        D_v1_t = u_b * abs(D_v1_n) * -v12_c_hat
+        D_w1 = 2.5 / R1 * ptmath.cross(unit_x, D_v1_t)
+        D_v2_t = -(m1 / m2) * D_v1_t
+        D_w2 = 2.5 / R2 * ptmath.cross(-unit_x, D_v2_t)
         rvw1_f[1] = rvw1[1] + D_v1_t
         rvw1_f[2] = rvw1[2] + D_w1
-        rvw2_f[1] = rvw2[1] - D_v1_t
-        rvw2_f[2] = rvw2[2] + D_w1
+        rvw2_f[1] = rvw2[1] + D_v2_t
+        rvw2_f[2] = rvw2[2] + D_w2
 
         # calculate new relative contact velocity
-        v1_c_slip = ptmath.surface_velocity(rvw1_f, unit_x, R)
-        v2_c_slip = ptmath.surface_velocity(rvw2_f, -unit_x, R)
+        v1_c_slip = ptmath.surface_velocity(rvw1_f, unit_x, R1)
+        v2_c_slip = ptmath.surface_velocity(rvw2_f, -unit_x, R2)
         v12_c_slip = v1_c_slip - v2_c_slip
 
     # if there was no relative velocity to begin with, or if slip changed directions,
     # then slip condition is invalid so we need to calculate no-slip condition
     if not has_relative_velocity or np.dot(v12_c, v12_c_slip) <= 0:  # type: ignore
         # velocity tangent component for no-slip condition
-        D_v1_t = -(1.0 / 7.0) * (
-            rvw1[1] - rvw2[1] + R * ptmath.cross(rvw1[2] + rvw2[2], unit_x)
-        )
-        D_w1 = -(5.0 / 14.0) * (
-            ptmath.cross(unit_x, rvw1[1] - rvw2[1]) / R + rvw1[2] + rvw2[2]
-        )
+        D_v1_t = -(2.0 / 7.0) * v12_c / (1 + m1 / m2)
+        D_w1 = 2.5 / R1 * ptmath.cross(unit_x, D_v1_t)
+        D_v2_t = -(m1 / m2) * D_v1_t
+        D_w2 = 2.5 / R2 * ptmath.cross(-unit_x, D_v2_t)
         rvw1_f[1] = rvw1[1] + D_v1_t
         rvw1_f[2] = rvw1[2] + D_w1
         rvw2_f[1] = rvw2[1] - D_v1_t
@@ -120,8 +122,11 @@ class FrictionalInelastic(CoreBallBallCollision):
         """Resolves the collision."""
         rvw1, rvw2 = _resolve_ball_ball(
             ball1.state.rvw.copy(),
-            ball2.state.rvw.copy(),
+            ball1.params.m,
             ball1.params.R,
+            ball2.state.rvw.copy(),
+            ball2.params.m,
+            ball2.params.R,
             u_b=self.friction.calculate_friction(ball1, ball2),
             # Average the coefficient of restitution parameters for the two balls
             e_b=(ball1.params.e_b + ball2.params.e_b) / 2,


### PR DESCRIPTION
Update ball_ball/frictional_inelastic to support collisions between balls of different sizes.

I checked the A-14 and A-27 plots before and after this change (See my other [PR](https://github.com/ekiefl/pooltool/pull/258)).  They appear *slightly* different, which is pretty annoying.  It might be floating point error, but I'm surprised it's noticeable at all on the plots.