### PR TITLE
Add 3D ball-pocket detection

### DIFF
--- a/pooltool/evolution/event_based/detect/ball_pocket.py
+++ b/pooltool/evolution/event_based/detect/ball_pocket.py
@@ -5,7 +5,10 @@ import numpy as np
 import pooltool.constants as const
 from pooltool.events import Event, EventType, ball_pocket_collision, null_event
 from pooltool.evolution.event_based.cache import CollisionCache
-from pooltool.physics.motion.solve import ball_pocket_collision_time
+from pooltool.physics.motion.solve import (
+    ball_pocket_collision_time,
+    ball_pocket_collision_time_airborne,
+)
 from pooltool.system.datatypes import System
 
 
@@ -57,4 +60,59 @@ def get_next_ball_pocket_2d_event(
 def get_next_ball_pocket_3d_event(
     shot: System, collision_cache: CollisionCache
 ) -> Event:
-    return null_event(np.inf)
+    """Detect the next ball-pocket collision in 3D mode.
+
+    Airborne balls use :func:`ball_pocket_collision_time_airborne`, which models the
+    pocket as a vertical cylinder and accounts for the parabolic z-trajectory.
+    Non-airborne, translating balls delegate to the same 2D detection routine as
+    :func:`get_next_ball_pocket_2d_event`.
+    """
+    if not shot.table.has_pockets:
+        return null_event(np.inf)
+
+    cache = collision_cache.times.setdefault(EventType.BALL_POCKET, {})
+
+    for ball in shot.balls.values():
+        state = ball.state
+        params = ball.params
+
+        for pocket in shot.table.pockets.values():
+            obj_ids = (ball.id, pocket.id)
+
+            if obj_ids in cache:
+                continue
+
+            if state.s in const.nontranslating:
+                cache[obj_ids] = np.inf
+                continue
+
+            if state.s == const.airborne:
+                dtau_E = ball_pocket_collision_time_airborne(
+                    rvw=state.rvw,
+                    a=pocket.a,
+                    b=pocket.b,
+                    r=pocket.radius,
+                    g=params.g,
+                    R=params.R,
+                )
+            else:
+                dtau_E = ball_pocket_collision_time(
+                    rvw=state.rvw,
+                    s=state.s,
+                    a=pocket.a,
+                    b=pocket.b,
+                    r=pocket.radius,
+                    mu=(params.u_s if state.s == const.sliding else params.u_r),
+                    m=params.m,
+                    g=params.g,
+                    R=params.R,
+                )
+            cache[obj_ids] = shot.t + dtau_E
+
+    ball_id, pocket_id = min(cache, key=lambda k: cache[k])
+
+    return ball_pocket_collision(
+        ball=shot.balls[ball_id],
+        pocket=shot.table.pockets[pocket_id],
+        time=cache[(ball_id, pocket_id)],
+    )

--- a/pooltool/physics/motion/solve.py
+++ b/pooltool/physics/motion/solve.py
@@ -8,7 +8,7 @@ import pooltool.constants as const
 import pooltool.physics.evolve as evolve
 import pooltool.ptmath as ptmath
 from pooltool.physics.utils import get_airborne_time, rel_velocity
-from pooltool.ptmath.roots import quartic
+from pooltool.ptmath.roots import quadratic, quartic
 from pooltool.ptmath.roots.core import get_real_positive_smallest_root
 
 
@@ -421,6 +421,100 @@ def ball_pocket_collision_time(
             )
         )
     )
+
+
+@jit(nopython=True, cache=const.use_numba_cache)
+def ball_pocket_collision_time_airborne(
+    rvw: NDArray[np.float64],
+    a: float,
+    b: float,
+    r: float,
+    g: float,
+    R: float,
+) -> float:
+    """Determine the ball-pocket collision time for an airborne ball.
+
+    The behavior is somewhat complicated. Here is the procedure.
+
+    Strategy 1: The xy-coordinates of where the ball lands are calculated. If that falls
+    within the pocket circle, a collision is returned. The collision time is chosen to
+    be just less than the collision time for the table collision, to guarantee temporal
+    precedence over the table collision.
+
+    Strategy 2: Otherwise, the influx and outflux collision times are calculated between
+    the ball center and a vertical cylinder that extends from the pocket's circle.
+    Influx collision refers to the collision with the outside of the cylinder's wall.
+    The outflux collision refers to the collision with the inside of the cylinder's wall
+    and occurs later in time. Since there is no deceleration in the xy-plane for an
+    airborne ball, an outflux collision is expected, meaning we expect 2 finite roots.
+    (This is only violated if the ball starts inside the cylinder, which results in at
+    most an outflux collision). The strategy is to see what the ball height is at the
+    time of the influx collision (``h0``) and the outflux collision (``hf``), because
+    from these we can determine whether or not the ball is considered to enter the
+    pocket. The following logic is used:
+
+        - ``h0 < R``: The ball passes through the playing surface plane before
+          intersecting the pocket cylinder, guaranteeing that a ball-table collision
+          occurs. Infinity is returned.
+        - ``hf <= (7/5)*R``: If the outflux height is less than ``(7/5)*R``, the ball
+          is considered to be pocketed. This threshold height implicitly models the
+          fact that high velocity balls that are slightly airborne collide with table
+          geometry at the back of the pocket, ricocheting the ball into the pocket.
+          The average of the influx and outflux collision times is returned.
+        - ``hf > (7/5)*R``: The ball is considered to fly over the pocket. Infinity is
+          returned.
+    """
+    phi = ptmath.angle(rvw[1])
+    v = ptmath.norm2d(rvw[1])
+    cos_phi = np.cos(phi)
+    sin_phi = np.sin(phi)
+    bx, by = v * cos_phi, v * sin_phi
+
+    # Strategy 1: does the ball land inside the pocket circle?
+    airborne_time = get_airborne_time(rvw, R, g)
+    x = rvw[0, 0] + bx * airborne_time
+    y = rvw[0, 1] + by * airborne_time
+
+    if (x - a) ** 2 + (y - b) ** 2 < r * r:
+        return float(airborne_time - const.EPS)
+
+    # Strategy 2: does the ball's xy trajectory cross the pocket cylinder?
+    cx, cy = rvw[0, 0], rvw[0, 1]
+
+    # These match the non-airborne quartic coefficients, after setting ax=ay=0.
+    C = 0.5 * (bx * bx + by * by)
+    D = bx * (cx - a) + by * (cy - b)
+    E = 0.5 * (a * a + b * b + cx * cx + cy * cy - r * r) - (cx * a + cy * b)
+
+    roots = quadratic.solve(C, D, E)
+
+    atol = 1e-9
+    if abs(roots[0].imag) > atol or abs(roots[1].imag) > atol:
+        return np.inf
+
+    real_0 = roots[0].real
+    real_1 = roots[1].real
+    if real_0 <= real_1:
+        r1, r2 = real_0, real_1
+    else:
+        r1, r2 = real_1, real_0
+
+    if r1 < 0.0:
+        return np.inf
+
+    v0z = rvw[1, 2]
+    z0 = rvw[0, 2]
+
+    h0 = -0.5 * g * r1 * r1 + v0z * r1 + z0
+    hf = -0.5 * g * r2 * r2 + v0z * r2 + z0
+
+    if h0 < R:
+        return np.inf
+
+    if hf > 7.0 / 5.0 * R:
+        return np.inf
+
+    return (r1 + r2) / 2.0
 
 
 @jit(nopython=True, cache=const.use_numba_cache)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,9 @@ addopts = [
 testpaths = [
     "tests",
 ]
+pythonpath = [
+    "tests",
+]
 
 # [tool.pyright]
 # pyright config is stored in pyrightconfig.json (local) and pyrightconfig.ci.json (CI)

--- a/sandbox/airborne_demos.py
+++ b/sandbox/airborne_demos.py
@@ -8,12 +8,14 @@ Usage:
 import argparse
 
 import attrs
+import numpy as np
 
 from pooltool import constants as const
 from pooltool.evolution.engine import SimulationEngine
 from pooltool.evolution.event_based.simulate import simulate
 from pooltool.interact import show
 from pooltool.objects.ball.datatypes import Ball
+from pooltool.objects.ball.sets import BallSet
 from pooltool.objects.cue.datatypes import Cue
 from pooltool.objects.table.datatypes import Table
 from pooltool.physics.dimensionality import Dim
@@ -90,10 +92,93 @@ def jump() -> System:
     )
 
 
+def airborne_pocket_collision() -> System:
+    """Six airborne balls dropping toward a corner pocket from varied heights.
+
+    Exercises both Strategy 1 (landing directly inside the pocket) and Strategy 2
+    (xy trajectory crossing the pocket cylinder mid-fall) in
+    :func:`pooltool.physics.motion.solve.ball_pocket_collision_time_airborne`.
+    """
+    ball = Ball.create("cue")
+    scale = 0.18
+    ball.state.rvw = np.array(
+        [
+            [0.8, 0.2, 1.228575],
+            [1.8 * scale, -1.8 * scale, 1.5],
+            [0, 0, 0],
+        ]
+    )
+    ball.state.s = const.airborne
+
+    other = Ball.create("1")
+    scale = 0.27
+    other.state.rvw = np.array(
+        [
+            [0.8, 0.2, 1.0],
+            [1.8 * scale, -1.8 * scale, 1.5],
+            [0, 0, 0],
+        ]
+    )
+    other.state.s = const.airborne
+
+    another = Ball.create("2")
+    scale = 0.11
+    another.state.rvw = np.array(
+        [
+            [0.8, 0.2, 0.8],
+            [1.8 * scale, -1.8 * scale, 1.5],
+            [0, 0, 0],
+        ]
+    )
+    another.state.s = const.airborne
+
+    fast1 = Ball.create("3")
+    scale = 2
+    fast1.state.rvw = np.array(
+        [
+            [0.3, 0.7, fast1.params.R * 7 / 5],
+            [1.8 * scale, -1.8 * scale, 0.6],
+            [0, 0, 0],
+        ]
+    )
+    fast1.state.s = const.airborne
+
+    fast2 = Ball.create("4")
+    scale = 2
+    fast2.state.rvw = np.array(
+        [
+            [0.8, 0.2, fast2.params.R * 7 / 5],
+            [1.8 * scale, -1.8 * scale, -2.0],
+            [0, 0, 0],
+        ]
+    )
+    fast2.state.s = const.airborne
+
+    vertical = Ball.create("5")
+    vertical.state.rvw = np.array(
+        [
+            [1.0, -0.05, 0.75],
+            [0, 0, 0],
+            [0, 0, 0],
+        ]
+    )
+    vertical.state.s = const.airborne
+
+    shot = System(
+        cue=Cue(cue_ball_id="cue"),
+        table=Table.default(),
+        balls=(ball, other, another, fast1, fast2, vertical),
+    )
+    shot.set_ballset(BallSet("pooltool_pocket"))
+
+    return shot
+
+
 _map = {
     "drop": drop,
     "impulse_into": impulse_into,
     "jump": jump,
+    "pocket_collision": airborne_pocket_collision,
 }
 
 

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,0 +1,37 @@
+"""Shared test helpers.
+
+Plain functions (no pytest fixtures) that test modules import directly. Made
+discoverable via ``pythonpath = ["tests"]`` in ``pyproject.toml``.
+"""
+
+from __future__ import annotations
+
+import attrs
+
+from pooltool.evolution.engine import SimulationEngine
+from pooltool.physics.dimensionality import Dim
+from pooltool.physics.resolve.resolver import Resolver
+
+
+def patch_resolver_dims(resolver: Resolver, dim_value: Dim) -> None:
+    """Set every resolver strategy's ``dim`` to ``dim_value``, in place."""
+    for field in attrs.fields(type(resolver)):
+        strategy = getattr(resolver, field.name)
+        if hasattr(strategy, "dim"):
+            strategy.dim = dim_value
+
+
+def build_3d_engine(dim_value: Dim = Dim.THREE) -> SimulationEngine:
+    """A ``SimulationEngine(is_3d=True)`` whose strategies are patched to ``dim_value``.
+
+    Used by tests that need to exercise the 3D code path before real ``Dim.THREE``
+    resolvers exist for every event type.
+
+    TODO: This is a temporary measure. Drop the dim patching once every resolver
+    slot has a ``Dim.THREE``-capable strategy (cushion + ball-ball; tracked by
+    issues #308–#312). At that point this helper can be replaced by a direct
+    ``SimulationEngine(is_3d=True)`` construction.
+    """
+    resolver = Resolver.default()
+    patch_resolver_dims(resolver, dim_value)
+    return SimulationEngine(resolver=resolver, is_3d=True)

--- a/tests/evolution/event_based/test_ball_pocket.py
+++ b/tests/evolution/event_based/test_ball_pocket.py
@@ -1,0 +1,100 @@
+import numpy as np
+import pytest
+from _helpers import build_3d_engine
+
+import pooltool.constants as const
+from pooltool.events import EventType, filter_type
+from pooltool.evolution.event_based.cache import CollisionCache
+from pooltool.evolution.event_based.detect.ball_pocket import (
+    get_next_ball_pocket_3d_event,
+)
+from pooltool.evolution.event_based.simulate import simulate
+from pooltool.objects.ball.datatypes import Ball
+from pooltool.objects.cue.datatypes import Cue
+from pooltool.objects.table.datatypes import Table
+from pooltool.objects.table.specs import TableType
+from pooltool.physics.motion.solve import ball_pocket_collision_time_airborne
+from pooltool.physics.utils import get_airborne_time
+from pooltool.system.datatypes import System
+
+R_DEFAULT = 0.028575
+G_DEFAULT = 9.81
+
+
+def _airborne_rvw(
+    x: float, y: float, z: float, vx: float = 0.0, vy: float = 0.0, vz: float = 0.0
+) -> np.ndarray:
+    return np.array(
+        [[x, y, z], [vx, vy, vz], [0.0, 0.0, 0.0]],
+        dtype=np.float64,
+    )
+
+
+def test_vertical_drop_into_pocket_center():
+    """Strategy 1: ball with no xy velocity drops straight into the pocket."""
+    a, b, r = 0.5, 0.5, 0.05
+    rvw = _airborne_rvw(0.5, 0.5, R_DEFAULT + 0.1)
+
+    t = ball_pocket_collision_time_airborne(rvw, a, b, r, G_DEFAULT, R_DEFAULT)
+
+    airborne_time = get_airborne_time(rvw, R_DEFAULT, G_DEFAULT)
+    assert t == pytest.approx(airborne_time - const.EPS)
+
+
+def test_fast_low_traverse_returns_cylinder_midpoint():
+    """Strategy 2: ball skims through the cylinder fast and low enough to ricochet.
+
+    With ``z0 = 1.2 R`` (between ``R`` and ``7/5 R``) and high horizontal velocity,
+    the influx and outflux heights both stay inside the ricochet window, so the
+    function returns the average of the crossing times.
+    """
+    a, b, r = 0.0, 0.0, 0.05
+    rvw = _airborne_rvw(-1.0, 0.0, 1.2 * R_DEFAULT, vx=100.0)
+
+    t = ball_pocket_collision_time_airborne(rvw, a, b, r, G_DEFAULT, R_DEFAULT)
+
+    # Trajectory crosses cylinder at t=0.0095 (influx) and t=0.0105 (outflux).
+    assert t == pytest.approx(0.01, abs=1e-6)
+
+
+def test_fly_over_returns_inf():
+    """Both influx and outflux above 7/5*R → ball flies over the pocket."""
+    a, b, r = 0.0, 0.0, 0.05
+    rvw = _airborne_rvw(-1.0, 0.0, 0.5, vx=1.0)
+
+    t = ball_pocket_collision_time_airborne(rvw, a, b, r, G_DEFAULT, R_DEFAULT)
+
+    assert t == np.inf
+
+
+def test_airborne_ball_above_pocket_is_pocketed():
+    """End-to-end: an airborne ball dropping into a pocket produces a BALL_POCKET event."""
+    table = Table.default()
+    pocket = next(iter(table.pockets.values()))
+
+    ball = Ball.create("cue")
+    ball.state.rvw[0, 0] = pocket.a
+    ball.state.rvw[0, 1] = pocket.b
+    ball.state.rvw[0, 2] = ball.params.R + 0.1
+    ball.state.s = const.airborne
+
+    shot = System(cue=Cue(), table=table, balls=(ball,))
+    simulate(shot, engine=build_3d_engine(), inplace=True)
+
+    pocket_events = filter_type(shot.events, EventType.BALL_POCKET)
+    assert len(pocket_events) == 1
+    assert shot.balls["cue"].state.s == const.pocketed
+
+
+def test_detector_skips_when_no_pockets():
+    """A table without pockets short-circuits to an inf-time null event."""
+    table = Table.default(TableType.BILLIARD)
+
+    ball = Ball.create("cue")
+    ball.state.rvw[0, 2] = ball.params.R + 0.1
+    ball.state.s = const.airborne
+
+    shot = System(cue=Cue(cue_ball_id="cue"), table=table, balls=(ball,))
+
+    event = get_next_ball_pocket_3d_event(shot, CollisionCache())
+    assert event.time == np.inf

--- a/tests/evolution/test_engine.py
+++ b/tests/evolution/test_engine.py
@@ -1,25 +1,15 @@
 import attrs
 import pytest
+from _helpers import build_3d_engine
 
 from pooltool.evolution.engine import SimulationEngine
 from pooltool.physics.dimensionality import Dim
-from pooltool.physics.resolve.resolver import Resolver
-
-
-def _patch_resolver_dims(resolver: Resolver, dim_value: Dim) -> None:
-    """Set every resolver strategy's dim to dim_value, in place."""
-    for field in attrs.fields(type(resolver)):
-        strategy = getattr(resolver, field.name)
-        if hasattr(strategy, "dim"):
-            strategy.dim = dim_value
 
 
 @pytest.fixture
 def engine_3d() -> SimulationEngine:
     """A SimulationEngine constructed with every resolver strategy patched to Dim.THREE."""
-    resolver = SimulationEngine().resolver
-    _patch_resolver_dims(resolver, Dim.THREE)
-    return SimulationEngine(resolver=resolver, is_3d=True)
+    return build_3d_engine()
 
 
 def test_default_engine_constructs():


### PR DESCRIPTION
# 3D ball-pocket detection

## Summary

Implements 3D ball-pocket detection for the `is_3d` simulation mode. The detector function `get_next_ball_pocket_3d_event` was previously a stub returning `null_event(np.inf)`, so airborne balls dropping into pockets were silently never detected. This PR ports the airborne ball-pocket detection logic from the deprecated `3d` branch, adapts it to main's quartic API, fixes a bug in the original, and adds the corresponding sandbox demo so the new path is exercisable end-to-end.

Closes #302.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced 3D pocket collision detection to accurately handle airborne balls using cylindrical-pocket and parabolic-trajectory physics modeling.

* **Tests**
  * Added comprehensive test coverage for airborne ball pocket collision scenarios, including vertical drops, traversals, and fly-overs.

* **Chores**
  * Updated test infrastructure and pytest configuration to support 3D simulation engine setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ekiefl/pooltool/pull/323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->