### PR TITLE
Vendor height-dependent ball shadows from 3d branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
       interval: "monthly"
     groups:
       lockfile-bumps:
-        update-types: ["patch", "minor"]
+        update-types: ["patch", "minor", "major"]

--- a/pooltool/ani/modes/ball_in_hand.py
+++ b/pooltool/ani/modes/ball_in_hand.py
@@ -276,8 +276,15 @@ class BallInHandMode(BaseMode):
             self.grabbed_ball.set_render_state_as_object_state()
             tasks.remove("grab_selection_highlight_animation")
 
+            tasks.add(
+                self.grabbed_ball._shadow_update_task,
+                self.grabbed_ball._shadow_task_name(),
+            )
+
     def add_grab_selection_highlight(self):
         if self.grabbed_ball is not None:
+            tasks.remove(self.grabbed_ball._shadow_task_name())
+
             tasks.add(
                 self.grab_selection_highlight_animation,
                 "grab_selection_highlight_animation",

--- a/pooltool/ani/modes/call_shot.py
+++ b/pooltool/ani/modes/call_shot.py
@@ -233,10 +233,18 @@ class CallShotMode(BaseMode):
             self.closest_ball.set_render_state_as_object_state()
             tasks.remove("call_shot_ball_highlight_animation")
 
+            tasks.add(
+                self.closest_ball._shadow_update_task,
+                self.closest_ball._shadow_task_name(),
+            )
+
     def add_ball_highlight(self):
         if self.closest_ball is not None:
             self.add_transparent_ball()
             self.trans_ball.hide()
+
+            tasks.remove(self.closest_ball._shadow_task_name())
+
             tasks.add(
                 self.call_shot_ball_highlight_animation,
                 "call_shot_ball_highlight_animation",

--- a/pooltool/objects/ball/render.py
+++ b/pooltool/objects/ball/render.py
@@ -15,6 +15,7 @@ from panda3d.core import (
     TransparencyAttrib,
 )
 
+import pooltool.ani.tasks as tasks
 import pooltool.ani.utils as autils
 import pooltool.constants as c
 from pooltool.ani.globals import Global
@@ -125,8 +126,7 @@ class BallRender(Render):
 
     def init_shadow(self):
         N = 20
-        start, stop = 0.5, 0.9  # fraction of ball radius
-        z_offset = 0.0005
+        start, stop = 0.4, 0.9  # fraction of ball radius
         scales = np.linspace(start, stop, N)
 
         if (ballset := self._ball.ballset) is not None:
@@ -146,7 +146,8 @@ class BallRender(Render):
             shadow_layer = Global.loader.loadModel(panda_path(shadow_path))
             shadow_layer.reparentTo(shadow_node)
             shadow_layer.setScale(self.get_scale_factor(shadow_layer) * scale)
-            shadow_layer.setZ(z_offset * (1 - i / N))
+            shadow_layer.setZ(0.0005 * (1 - i / N))
+            shadow_layer.setAlphaScale(np.exp(-i / N))
 
         return shadow_node
 
@@ -342,6 +343,45 @@ class BallRender(Render):
 
         ball.setHpr(0, 0, 0)
 
+    def _shadow_update_task(self, task):
+        """Update shadow scale/visibility each frame from the current ball height.
+
+        The shadow position is controlled by the playback sequence. If the shadow
+        position is updated within this task, it (1) lags behind the actual ball
+        position and (2) leads to crashes.
+        """
+        shadow_node = self.nodes["shadow"]
+
+        z = self.nodes["pos"].getZ()
+        R = self._ball.params.R
+
+        max_bottom_height = 0.13
+
+        bottom_height = max(z - R, 0)
+        if bottom_height >= max_bottom_height:
+            shadow_node.hide()
+        else:
+            if shadow_node.is_hidden():
+                shadow_node.show()
+
+            f = bottom_height / max_bottom_height
+
+            alpha = np.exp(-5 * f)
+            scale = 1 + 2.0 * f
+
+            shadow_node.setScale(scale)
+            shadow_node.setAlphaScale(alpha)
+
+        return task.cont
+
+    def _shadow_task_name(self) -> str:
+        return f"update_shadow_{self._ball.id}"
+
     def render(self):
         super().render()
         self.init_sphere()
+        tasks.add(self._shadow_update_task, self._shadow_task_name())
+
+    def remove_nodes(self):
+        tasks.remove(self._shadow_task_name())
+        super().remove_nodes()


### PR DESCRIPTION
## Summary

Vendors PR #180 from the `3d` branch into `main`, closing #319.

## Known limitation — shadow clipping (to address later)

When a ball is airborne near a rail, the shadow expands well past the ball's radius and visibly **bleeds past the cushion plane**, overwriting baked-in shadows in the table GLB.

Leaving this for a follow-up. Likely paths: stencil/mask via shader against a playing-surface texture (handles pocket cutouts and soft fade), or geometric clipping that derives inward normals from the table center (robust but still rectangular).