### PR TITLE
Touchup call sigs and docstrings in Han 2005

### DIFF
--- a/pooltool/physics/resolve/ball_cushion/han_2005/properties.py
+++ b/pooltool/physics/resolve/ball_cushion/han_2005/properties.py
@@ -1,35 +1,33 @@
 import numpy as np
+from numpy.typing import NDArray
 
 import pooltool.ptmath as ptmath
 
 
-def get_ball_cushion_restitution(rvw, e_c):
+def get_ball_cushion_restitution(rvw: NDArray[np.float64], e_c: float):
     """Get restitution coefficient dependent on ball state
 
-    Parameters
-    ==========
-    rvw: np.array
-        Assumed to be in reference frame such that <1,0,0> points
-        perpendicular to the cushion, and in the direction away from the table
+    Args:
+        rvw:
+            Assumed to be in reference frame such that <1,0,0> points perpendicular to
+            the cushion, and in the direction away from the table.
 
-    Notes
-    =====
-    - https://essay.utwente.nl/59134/1/scriptie_J_van_Balen.pdf suggests a constant
-      value of 0.85
+    Notes:
+        - https://essay.utwente.nl/59134/1/scriptie_J_van_Balen.pdf suggests a constant
+          value of 0.85
     """
 
     return e_c
     return max([0.40, 0.50 + 0.257 * rvw[1, 0] - 0.044 * rvw[1, 0] ** 2])
 
 
-def get_ball_cushion_friction(rvw, f_c):
+def get_ball_cushion_friction(rvw: NDArray[np.float64], f_c: float):
     """Get friction coeffecient depend on ball state
 
-    Parameters
-    ==========
-    rvw: np.array
-        Assumed to be in reference frame such that <1,0,0> points
-        perpendicular to the cushion, and in the direction away from the table
+    Args:
+        rvw:
+            Assumed to be in reference frame such that <1,0,0> points perpendicular to
+            the cushion, and in the direction away from the table.
     """
 
     ang = ptmath.angle(rvw[1])


### PR DESCRIPTION
Was planning on detailing somewhere that Han will not support 3D but couldn't find a good place. I think a full page in the docs should eventually be a user guide on model dimension support. For developers/power users it's clear because each resolver defines a `Dim` enum.