### PR TITLE
Replace Dependabot with Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "schedule": [
+    "before 6am on the first day of the month"
+  ],
+  "prConcurrentLimit": 5,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": [
+      "before 6am on the first day of the month"
+    ]
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-non-major"
+    },
+    {
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "dependencyDashboardApproval": true
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "groupName": "security updates",
+    "labels": [
+      "security"
+    ]
+  }
+}


### PR DESCRIPTION
Switches dependency automation from Dependabot to Renovate to fix the
recurring problem of Dependabot opening one PR per security advisory
regardless of the grouping config (dependabot/dependabot-core#14355).

## Behavior under this config

| When | What happens |
|---|---|
| 1st of each month, ~6am UTC | Up to two PRs: one bundling all patch+minor bumps (\`all non-major dependencies\`), one \`Lock file maintenance\` PR refreshing \`uv.lock\` for transitive bumps |
| Security advisory drops | Bundled into a single rolling \`security updates\` PR (re-rolls if already open, new PR if previous was merged); ignores schedule, opens immediately |
| Major version available | Appears as a checkbox on the Dependency Dashboard issue; no PR until you tick it |
| Anytime | Hard ceiling of 5 open Renovate PRs |

A single rolling \"Dependency Dashboard\" issue shows everything pending.

## Migration checklist (to do once this merges)

- [ ] Install the Mend Renovate GitHub App on this repo: https://github.com/apps/renovate
- [ ] Settings → Code security: disable Dependabot version updates and Dependabot security updates (leave Dependabot alerts on — Renovate uses the same advisory data)
- [ ] Close the 6 open Dependabot PRs (#336, #352, #356, #357, #358, #359); Renovate's first scan will re-detect and bundle them