### PR TITLE
Renovate: ignore docs dependency-group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,19 @@
   },
   "packageRules": [
     {
+      "description": "Do not update documentation dependencies (the [dependency-groups].docs entries in pyproject.toml). New deps added to that group are excluded automatically.",
+      "matchManagers": [
+        "pep621"
+      ],
+      "matchDepTypes": [
+        "dependency-groups"
+      ],
+      "matchJsonata": [
+        "managerData.depGroup = 'docs'"
+      ],
+      "enabled": false
+    },
+    {
       "matchUpdateTypes": [
         "patch",
         "minor"


### PR DESCRIPTION
Documentation deps in \`[dependency-groups].docs\` (sphinx, furo, myst-parser, sphinx-autoapi, astroid, nbsphinx, sphinx-autobuild, sphinx-togglebutton, sphinx-tabs, sphinx-copybutton) often have breaking changes between versions. Stop Renovate from auto-PRing bumps for them.

## How

Uses Renovate's \`matchJsonata\` matcher against \`managerData.depGroup\`, which the \`pep621\` manager attaches to every extracted dependency (see [renovate source](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/pep621/schema.ts)). This selects by **group name**, not by package name — so any package added to (or removed from) the docs group in pyproject.toml is automatically picked up. No hardcoded list to maintain.

\`\`\`json
{
  "matchManagers": ["pep621"],
  "matchDepTypes": ["dependency-groups"],
  "matchJsonata": ["managerData.depGroup = 'docs'"],
  "enabled": false
}
\`\`\`

## Effect

| Group | Renovate behavior |
|---|---|
| \`[dependency-groups].docs\` | **Skipped** — no version-update PRs, no security PRs, no dashboard entries |
| \`[dependency-groups].dev\` | Unchanged — still in the monthly non-major bundle |
| \`[project.dependencies]\` | Unchanged |

Docs deps still receive transitive lockfile bumps via the monthly \`lockFileMaintenance\` PR.

## Caveat

Renovate will not open security PRs for these packages either. If a doc dep ever has a CVE you care about, bump it manually.