### PR TITLE
Renovate: ignore Python itself

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,13 @@
       "enabled": false
     },
     {
+      "description": "Do not bump Python itself. The lower bound in pyproject.toml's requires-python defines the minimum Python users must have, and the .python-version pin is the project's dev interpreter; both are managed by hand.",
+      "matchPackageNames": [
+        "python"
+      ],
+      "enabled": false
+    },
+    {
       "matchUpdateTypes": [
         "patch",
         "minor"


### PR DESCRIPTION
PR #364 bundled the JupyterLab and msgpack security fixes with two Python bumps that should never be Renovate's call:

- \`.python-version\`: \`3.13\` → \`3.14\` (dev interpreter pin)
- \`pyproject.toml\` \`requires-python\`: \`>=3.10,<3.14\` → \`>=3.14,<3.15\` (would break installs for every user not on 3.14)

Both files are deliberate version-policy decisions, not auto-bumpable dependencies.

## Rule

\`\`\`json
{
  "matchPackageNames": ["python"],
  "enabled": false
}
\`\`\`

Single rule covers both because Renovate's \`pep621\` manager (for \`requires-python\`) and \`pyenv\` manager (for \`.python-version\`) both set \`packageName: "python"\` on the extracted dep.

## Effect

- The two \`python\` rows in the dashboard's "Detected Dependencies" section will no longer surface as updates.
- Once merged, Renovate will re-roll PR #364 without the \`.python-version\` and \`requires-python\` lines. The legitimate fixes (\`jupyterlab\`, \`msgpack\`, plus the non-major bundle members \`llvmlite\`, \`uv_build\`) remain.

To bump Python in the future, edit either file by hand.