### PR TITLE
Renovate: widen ranges instead of replacing

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,13 @@
       "enabled": false
     },
     {
+      "description": "For PyPI deps in pyproject.toml, widen the upper bound to include the new version rather than tightening the lower bound. Preserves the widest possible install footprint for users of the published pooltool-billiards package.",
+      "matchManagers": [
+        "pep621"
+      ],
+      "rangeStrategy": "widen"
+    },
+    {
       "matchUpdateTypes": [
         "patch",
         "minor"


### PR DESCRIPTION
Same family as #363 and #365 — correcting a Renovate default that's wrong for a published library.

## The bug

PR #364's diff includes:

\`\`\`diff
-    "llvmlite>=0.44.0,<0.46"
+    "llvmlite>=0.47,<0.48"
\`\`\`

Renovate's default \`rangeStrategy: "auto"\` resolves to \`"replace"\` for pep621, which rewrites the entire range — silently raising the minimum supported \`llvmlite\` for downstream installs of \`pooltool-billiards\` from \`0.44.0\` to \`0.47\`. There is no compatibility basis for that change; it's an artifact of the bot writing the manifest as if pooltool were an application pinning its own deps, not a library publishing a wide compatibility range.

Confirmed by the [PEP 440 rangeStrategy docs](https://github.com/renovatebot/renovate/blob/main/docs/usage/configuration-options.md#rangestrategy):

> \`replace\` = Replace the range with a newer one if the new version falls outside it

## The fix

\`\`\`json
{
  "matchManagers": ["pep621"],
  "rangeStrategy": "widen"
}
\`\`\`

> \`widen\` = Widen the range with newer one

PEP 440 widen is fully implemented (\`lib/modules/versioning/pep440/range.ts:418\`). For \`>=0.44.0,<0.46\` + new version \`0.47.0\`, it preserves the \`>=0.44.0\` lower bound and bumps the cap to include the new version. For deps without an upper bound (most of \`pyproject.toml\`), widen is a no-op at the range level; the lockfile still gets the new version.

## Effect on PR #364 after re-roll

| Dep | Current diff (replace) | After widen |
|---|---|---|
| \`llvmlite\` | \`>=0.44.0,<0.46\` → \`>=0.47,<0.48\` | \`>=0.44.0,<0.46\` → \`>=0.44.0,<0.48\` |
| \`uv_build\` | \`>=0.10.9,<0.11\` → \`>=0.11.25,<0.12\` | \`>=0.10.9,<0.11\` → \`>=0.10.9,<0.12\` |
| \`msgpack\`, \`jupyterlab\` | (no upper bound) | unchanged at range level; lockfile bumped |

Maximizes the dependency resolution radius for users.