### PR TITLE
Ek/make kiss 3d linear cushion

### DIFF
--- a/pooltool/physics/resolve/ball_cushion/core.py
+++ b/pooltool/physics/resolve/ball_cushion/core.py
@@ -56,21 +56,6 @@ class BallCCushionCollisionStrategy(_BaseCircularStrategy, Protocol):
 class CoreBallLCushionCollision(ABC):
     """Operations used by every ball-linear cushion collision resolver"""
 
-    def _apply_fallback_positioning_linear(
-        self, ball: Ball, cushion: LinearCushionSegment, spacer: float
-    ) -> np.ndarray:
-        """Place the ball at R + spacer from the cushion along the geometric normal.
-
-        Used when the ball is nontranslating (no velocity to trace back along) or
-        when the velocity-based correction would produce an excessive displacement.
-        """
-        c = ptmath.point_on_line_closest_to_point(
-            cushion.p1, cushion.p2, ball.state.rvw[0]
-        )
-        c[2] = ball.state.rvw[0, 2]
-        direction = ptmath.unit_vector(ball.state.rvw[0] - c)
-        return c + (ball.params.R + spacer) * direction
-
     def make_kiss(self, ball: Ball, cushion: LinearCushionSegment) -> Ball:
         """Translate the ball along its velocity so it nearly touches the cushion.
 
@@ -88,10 +73,7 @@ class CoreBallLCushionCollision(ABC):
         spacer = const.MIN_DIST
 
         if ball.state.s in const.nontranslating:
-            ball.state.rvw[0] = self._apply_fallback_positioning_linear(
-                ball, cushion, spacer
-            )
-            return ball
+            return _apply_fallback_positioning_linear(ball, cushion, spacer)
 
         n = cushion.get_normal_xy(ball.xyz)
         n = n if np.dot(n, v) > 0 else -n
@@ -104,18 +86,10 @@ class CoreBallLCushionCollision(ABC):
         t = t1 if abs(t1) < abs(t2) else t2
 
         if ptmath.norm3d(t * v) > 5 * spacer:
-            ball.state.rvw[0] = self._apply_fallback_positioning_linear(
-                ball, cushion, spacer
-            )
-            return ball
+            return _apply_fallback_positioning_linear(ball, cushion, spacer)
 
         ball.state.rvw[0] = r + t * v
-
-        # Guard against z-drift.
-        if ball.state.rvw[0, 2] < ball.params.R:
-            ball.state.rvw[0, 2] = ball.params.R
-        if ball.state.rvw[0, 2] > ball.params.R and ball.state.s != const.airborne:
-            ball.state.rvw[0, 2] = ball.params.R
+        ball = _guard_against_z_drift(ball)
 
         return ball
 
@@ -140,18 +114,6 @@ class CoreBallLCushionCollision(ABC):
 class CoreBallCCushionCollision(ABC):
     """Operations used by every ball-circular cushion collision resolver"""
 
-    def _apply_fallback_positioning_circular(
-        self, ball: Ball, cushion: CircularCushionSegment, spacer: float
-    ) -> np.ndarray:
-        """Place the ball at R + radius + spacer from the cushion center along the radial.
-
-        Used when the ball is nontranslating (no velocity to trace back along) or
-        when the velocity-based correction would produce an excessive displacement.
-        """
-        c = np.array([cushion.center[0], cushion.center[1], ball.state.rvw[0, 2]])
-        direction = ptmath.unit_vector(ball.state.rvw[0] - c)
-        return c + (ball.params.R + cushion.radius + spacer) * direction
-
     def make_kiss(self, ball: Ball, cushion: CircularCushionSegment) -> Ball:
         """Translate the ball along its velocity so it nearly touches the cushion.
 
@@ -168,10 +130,7 @@ class CoreBallCCushionCollision(ABC):
         spacer = const.MIN_DIST
 
         if ball.state.s in const.nontranslating:
-            ball.state.rvw[0] = self._apply_fallback_positioning_circular(
-                ball, cushion, spacer
-            )
-            return ball
+            return _apply_fallback_positioning_circular(ball, cushion, spacer)
 
         c = np.array([cushion.center[0], cushion.center[1], r[2]])
         diff = r - c
@@ -190,18 +149,10 @@ class CoreBallCCushionCollision(ABC):
         t = roots[np.abs(roots).argmin()]
 
         if ptmath.norm3d(t * v) > 5 * spacer:
-            ball.state.rvw[0] = self._apply_fallback_positioning_circular(
-                ball, cushion, spacer
-            )
-            return ball
+            return _apply_fallback_positioning_circular(ball, cushion, spacer)
 
         ball.state.rvw[0] = r + t * v
-
-        # Guard against z-drift.
-        if ball.state.rvw[0, 2] < ball.params.R:
-            ball.state.rvw[0, 2] = ball.params.R
-        if ball.state.rvw[0, 2] > ball.params.R and ball.state.s != const.airborne:
-            ball.state.rvw[0, 2] = ball.params.R
+        ball = _guard_against_z_drift(ball)
 
         return ball
 
@@ -215,3 +166,43 @@ class CoreBallCCushionCollision(ABC):
         ball = self.make_kiss(ball, cushion)
 
         return self.solve(ball, cushion)  # type: ignore
+
+
+def _guard_against_z_drift(ball: Ball) -> Ball:
+    if ball.state.rvw[0, 2] < ball.params.R:
+        ball.state.rvw[0, 2] = ball.params.R
+    if ball.state.rvw[0, 2] > ball.params.R and ball.state.s != const.airborne:
+        ball.state.rvw[0, 2] = ball.params.R
+
+    return ball
+
+
+def _apply_fallback_positioning_linear(
+    ball: Ball, cushion: LinearCushionSegment, spacer: float
+) -> Ball:
+    """Place the ball at R + spacer from the cushion along the geometric normal.
+
+    Used when the ball is nontranslating (no velocity to trace back along) or
+    when the velocity-based correction would produce an excessive displacement.
+    """
+    c = ptmath.point_on_line_closest_to_point(cushion.p1, cushion.p2, ball.state.rvw[0])
+    c[2] = ball.state.rvw[0, 2]
+    direction = ptmath.unit_vector(ball.state.rvw[0] - c)
+    ball.state.rvw[0] = c + (ball.params.R + spacer) * direction
+
+    return _guard_against_z_drift(ball)
+
+
+def _apply_fallback_positioning_circular(
+    ball: Ball, cushion: CircularCushionSegment, spacer: float
+) -> Ball:
+    """Place the ball at R + radius + spacer from the cushion center along the radial.
+
+    Used when the ball is nontranslating (no velocity to trace back along) or
+    when the velocity-based correction would produce an excessive displacement.
+    """
+    c = np.array([cushion.center[0], cushion.center[1], ball.state.rvw[0, 2]])
+    direction = ptmath.unit_vector(ball.state.rvw[0] - c)
+    ball.state.rvw[0] = c + (ball.params.R + cushion.radius + spacer) * direction
+
+    return _guard_against_z_drift(ball)

--- a/pooltool/physics/resolve/ball_cushion/core.py
+++ b/pooltool/physics/resolve/ball_cushion/core.py
@@ -67,9 +67,11 @@ class CoreBallLCushionCollision(ABC):
     def make_kiss(self, ball: Ball, cushion: LinearCushionSegment) -> Ball:
         """Translate the ball along its velocity so it nearly touches the cushion.
 
-        Solves a quadratic equation for the time offset t such that the ball's
-        perpendicular distance to the cushion line equals R + spacer, then moves
-        the ball to r + t * v. The smallest-magnitude real root is chosen.
+        The cushion is modeled as a thin cylinder of radius ``cushion.nose_radius``
+        around the line through ``p1`` and ``p2``. Solves a quadratic equation for
+        the time offset t such that the ball's perpendicular distance to the
+        cushion line equals ``R + nose_radius + spacer``, then moves the ball to
+        ``r + t * v``. The smallest-magnitude real root is chosen.
 
         If the ball is nontranslating or the displacement would exceed
         FALLBACK_DISPLACEMENT_FACTOR * spacer (e.g. on a near-grazing trajectory,
@@ -88,7 +90,7 @@ class CoreBallLCushionCollision(ABC):
         q0 = r - cushion.p1
         v_perp = v - np.dot(v, u) * u
         q0_perp = q0 - np.dot(q0, u) * u
-        target = R + spacer
+        target = R + cushion.nose_radius + spacer
 
         alpha = np.dot(v_perp, v_perp)
         beta = 2 * np.dot(q0_perp, v_perp)
@@ -178,7 +180,7 @@ class CoreBallCCushionCollision(ABC):
 def _apply_fallback_positioning_linear(
     ball: Ball, cushion: LinearCushionSegment, spacer: float
 ) -> Ball:
-    """Place the ball at R + spacer from the cushion line along the perpendicular.
+    """Place the ball at R + nose_radius + spacer from the cushion line along the perpendicular.
 
     Used when the ball is nontranslating (no velocity to trace back along) or
     when the velocity-based correction would produce an excessive displacement.
@@ -186,7 +188,7 @@ def _apply_fallback_positioning_linear(
     R = ball.params.R
     c = ptmath.point_on_line_closest_to_point(cushion.p1, cushion.p2, ball.state.rvw[0])
     direction = ptmath.unit_vector(ball.state.rvw[0] - c)
-    candidate = c + (R + spacer) * direction
+    candidate = c + (R + cushion.nose_radius + spacer) * direction
     ball.state.rvw[0] = _constrain_to_table(
         candidate, cushion, R, airborne=ball.state.s == const.airborne
     )

--- a/pooltool/physics/resolve/ball_cushion/core.py
+++ b/pooltool/physics/resolve/ball_cushion/core.py
@@ -110,6 +110,13 @@ class CoreBallLCushionCollision(ABC):
             return ball
 
         ball.state.rvw[0] = r + t * v
+
+        # Guard against z-drift.
+        if ball.state.rvw[0, 2] < ball.params.R:
+            ball.state.rvw[0, 2] = ball.params.R
+        if ball.state.rvw[0, 2] > ball.params.R and ball.state.s != const.airborne:
+            ball.state.rvw[0, 2] = ball.params.R
+
         return ball
 
     def resolve(
@@ -189,6 +196,13 @@ class CoreBallCCushionCollision(ABC):
             return ball
 
         ball.state.rvw[0] = r + t * v
+
+        # Guard against z-drift.
+        if ball.state.rvw[0, 2] < ball.params.R:
+            ball.state.rvw[0, 2] = ball.params.R
+        if ball.state.rvw[0, 2] > ball.params.R and ball.state.s != const.airborne:
+            ball.state.rvw[0, 2] = ball.params.R
+
         return ball
 
     def resolve(

--- a/pooltool/physics/resolve/ball_cushion/core.py
+++ b/pooltool/physics/resolve/ball_cushion/core.py
@@ -68,13 +68,13 @@ class CoreBallLCushionCollision(ABC):
         """Translate the ball along its velocity so it nearly touches the cushion.
 
         Solves a quadratic equation for the time offset t such that the ball's
-        3D perpendicular distance to the cushion line equals R + spacer, then moves
+        perpendicular distance to the cushion line equals R + spacer, then moves
         the ball to r + t * v. The smallest-magnitude real root is chosen.
 
         If the ball is nontranslating or the displacement would exceed
         FALLBACK_DISPLACEMENT_FACTOR * spacer (e.g. on a near-grazing trajectory,
         or when the ball's velocity is parallel to the cushion axis), falls back to
-        positioning along the 3D perpendicular from the cushion line.
+        positioning along the perpendicular from the cushion line.
         """
         r = ball.state.rvw[0]
         v = ball.state.rvw[1]
@@ -100,7 +100,9 @@ class CoreBallLCushionCollision(ABC):
         if ptmath.norm3d(t * v) > FALLBACK_DISPLACEMENT_FACTOR * spacer:
             return _apply_fallback_positioning_linear(ball, cushion, spacer)
 
-        ball.state.rvw[0] = _lift_above_table(r + t * v, cushion, R)
+        ball.state.rvw[0] = _constrain_to_table(
+            r + t * v, cushion, R, airborne=ball.state.s == const.airborne
+        )
 
         return ball
 
@@ -157,7 +159,7 @@ class CoreBallCCushionCollision(ABC):
         if ptmath.norm3d(t * v) > FALLBACK_DISPLACEMENT_FACTOR * spacer:
             return _apply_fallback_positioning_circular(ball, cushion, spacer)
 
-        ball.state.rvw[0] = r + t * v
+        ball.state.rvw[0] = _clamp_to_table(r + t * v, R)
 
         return ball
 
@@ -176,7 +178,7 @@ class CoreBallCCushionCollision(ABC):
 def _apply_fallback_positioning_linear(
     ball: Ball, cushion: LinearCushionSegment, spacer: float
 ) -> Ball:
-    """Place the ball at R + spacer from the cushion line along the 3D perpendicular.
+    """Place the ball at R + spacer from the cushion line along the perpendicular.
 
     Used when the ball is nontranslating (no velocity to trace back along) or
     when the velocity-based correction would produce an excessive displacement.
@@ -185,29 +187,48 @@ def _apply_fallback_positioning_linear(
     c = ptmath.point_on_line_closest_to_point(cushion.p1, cushion.p2, ball.state.rvw[0])
     direction = ptmath.unit_vector(ball.state.rvw[0] - c)
     candidate = c + (R + spacer) * direction
-    ball.state.rvw[0] = _lift_above_table(candidate, cushion, R)
+    ball.state.rvw[0] = _constrain_to_table(
+        candidate, cushion, R, airborne=ball.state.s == const.airborne
+    )
 
     return ball
 
 
-def _lift_above_table(
+def _clamp_to_table(pos: np.ndarray, R: float) -> np.ndarray:
+    """Raise ``pos[2]`` to ``R`` if below, leave unchanged otherwise.
+
+    For vertical-axis cushions (the current circular cushion model), this preserves
+    distance from the cushion axis since the axis runs along z.
+    """
+    if pos[2] >= R:
+        return pos
+    new_pos = pos.copy()
+    new_pos[2] = R
+    return new_pos
+
+
+def _constrain_to_table(
     pos: np.ndarray,
     cushion: LinearCushionSegment,
     R: float,
+    airborne: bool,
 ) -> np.ndarray:
-    """Rotate ``pos`` around the cushion axis until ``pos[2] == R``, preserving its
-    distance from the cushion line. Returns ``pos`` unchanged if ``pos[2] >= R``.
+    """Rotate ``pos`` around the cushion axis to enforce the ball's table constraint.
 
-    Constrains a candidate ball position to the table (z = R) when the 3D
-    perpendicular from the cushion line would otherwise place it below. The ball
-    traces a circle around the cushion axis at the existing arm length, and is
-    moved along that circle to the intersection with the z = R plane that is on
-    the same side as the original position.
+    For non-airborne balls, the constraint is ``z == R`` exactly: the ball must rest on
+    the table. The perpendicular from the cushion line can place the candidate either
+    above or below R, and both directions need correcting — above is unphysical lift
+    (artificial PE gain), below is table penetration.
 
-    Degenerate cases (cushion axis nearly aligned with z, or arm too short to
-    reach z = R) return ``pos`` unchanged.
+    For airborne balls, the constraint is ``z >= R``: only lift when below R.
+
+    The rotation preserves the arm length (distance from cushion line) and keeps the
+    ball on its original side around the axis.
     """
-    if pos[2] >= R:
+    if airborne and pos[2] >= R:
+        return pos
+
+    if pos[2] == R:
         return pos
 
     c = ptmath.point_on_line_closest_to_point(cushion.p1, cushion.p2, pos)
@@ -216,22 +237,12 @@ def _lift_above_table(
     direction = arm / arm_len
 
     u = cushion.unit_axis
-    u_z = u[2]
-    sin_lat = np.sqrt(1.0 - u_z * u_z)
-    if sin_lat < 1e-12:
-        return pos
+    z_hat = np.array([0.0, 0.0, 1.0])
+    h_hat = np.array([u[1], -u[0], 0.0])
 
-    z_in_plane_unit = np.array(
-        [-u[0] * u_z, -u[1] * u_z, 1.0 - u_z * u_z], dtype=np.float64
-    ) / sin_lat
-    h_hat = np.cross(u, z_in_plane_unit)
-
-    a = (R - c[2]) / arm_len / sin_lat
-    if abs(a) > 1.0:
-        return pos
-
-    b = float(np.sign(np.dot(direction, h_hat))) * np.sqrt(1.0 - a * a)
-    new_direction = a * z_in_plane_unit + b * h_hat
+    a = (R - c[2]) / arm_len
+    b = np.sign(np.dot(direction, h_hat)) * np.sqrt(1.0 - a * a)
+    new_direction = a * z_hat + b * h_hat
 
     return c + arm_len * new_direction
 

--- a/pooltool/physics/resolve/ball_cushion/core.py
+++ b/pooltool/physics/resolve/ball_cushion/core.py
@@ -12,6 +12,14 @@ from pooltool.objects.table.components import (
 )
 from pooltool.physics.dimensionality import Dim
 
+FALLBACK_DISPLACEMENT_FACTOR = 5
+"""Multiplier on ``spacer`` defining the max make_kiss displacement before falling back.
+
+If the velocity-based correction would move the ball more than
+``FALLBACK_DISPLACEMENT_FACTOR * spacer`` (e.g. on a near-grazing trajectory), make_kiss
+falls back to positioning along the cushion normal instead.
+"""
+
 
 class _BaseLinearStrategy(Protocol):
     def make_kiss(self, ball: Ball, cushion: LinearCushionSegment) -> Ball: ...
@@ -85,7 +93,7 @@ class CoreBallLCushionCollision(ABC):
         t2 = (-(R + spacer) - d0) / vn
         t = t1 if abs(t1) < abs(t2) else t2
 
-        if ptmath.norm3d(t * v) > 5 * spacer:
+        if ptmath.norm3d(t * v) > FALLBACK_DISPLACEMENT_FACTOR * spacer:
             return _apply_fallback_positioning_linear(ball, cushion, spacer)
 
         ball.state.rvw[0] = r + t * v
@@ -140,14 +148,9 @@ class CoreBallCCushionCollision(ABC):
         gamma = diff[0] ** 2 + diff[1] ** 2 - target**2
 
         roots_complex = ptmath.roots.quadratic.solve(alpha, beta, gamma)
+        t = ptmath.roots.get_real_smallest_magnitude_root(roots_complex)
 
-        imag_mag = np.abs(roots_complex.imag)
-        real_mag = np.abs(roots_complex.real)
-        keep = (imag_mag / real_mag) < 1e-3
-        roots = roots_complex[keep].real
-        t = roots[np.abs(roots).argmin()]
-
-        if ptmath.norm3d(t * v) > 5 * spacer:
+        if ptmath.norm3d(t * v) > FALLBACK_DISPLACEMENT_FACTOR * spacer:
             return _apply_fallback_positioning_circular(ball, cushion, spacer)
 
         ball.state.rvw[0] = r + t * v

--- a/pooltool/physics/resolve/ball_cushion/core.py
+++ b/pooltool/physics/resolve/ball_cushion/core.py
@@ -67,13 +67,14 @@ class CoreBallLCushionCollision(ABC):
     def make_kiss(self, ball: Ball, cushion: LinearCushionSegment) -> Ball:
         """Translate the ball along its velocity so it nearly touches the cushion.
 
-        Solves a linear equation for the time offset t such that the ball's
-        perpendicular distance to the cushion line equals R + spacer, then moves
-        the ball to r + t * v. The perpendicular distance to a line is linear in t,
-        so no quadratic solver is needed.
+        Solves a quadratic equation for the time offset t such that the ball's
+        3D perpendicular distance to the cushion line equals R + spacer, then moves
+        the ball to r + t * v. The smallest-magnitude real root is chosen.
 
-        If the ball is nontranslating or the displacement would exceed 5 * spacer,
-        falls back to positioning along the geometric normal.
+        If the ball is nontranslating or the displacement would exceed
+        FALLBACK_DISPLACEMENT_FACTOR * spacer (e.g. on a near-grazing trajectory,
+        or when the ball's velocity is parallel to the cushion axis), falls back to
+        positioning along the 3D perpendicular from the cushion line.
         """
         r = ball.state.rvw[0]
         v = ball.state.rvw[1]
@@ -83,20 +84,23 @@ class CoreBallLCushionCollision(ABC):
         if ball.state.s in const.nontranslating:
             return _apply_fallback_positioning_linear(ball, cushion, spacer)
 
-        n = cushion.get_normal_xy(ball.xyz)
-        n = n if np.dot(n, v) > 0 else -n
+        u = cushion.unit_axis
+        q0 = r - cushion.p1
+        v_perp = v - np.dot(v, u) * u
+        q0_perp = q0 - np.dot(q0, u) * u
+        target = R + spacer
 
-        d0 = np.dot(r - cushion.p1, n)
-        vn = np.dot(v, n)
+        alpha = np.dot(v_perp, v_perp)
+        beta = 2 * np.dot(q0_perp, v_perp)
+        gamma = np.dot(q0_perp, q0_perp) - target**2
 
-        t1 = (R + spacer - d0) / vn
-        t2 = (-(R + spacer) - d0) / vn
-        t = t1 if abs(t1) < abs(t2) else t2
+        roots_complex = ptmath.roots.quadratic.solve(alpha, beta, gamma)
+        t = ptmath.roots.get_real_smallest_magnitude_root(roots_complex)
 
         if ptmath.norm3d(t * v) > FALLBACK_DISPLACEMENT_FACTOR * spacer:
             return _apply_fallback_positioning_linear(ball, cushion, spacer)
 
-        ball.state.rvw[0] = r + t * v
+        ball.state.rvw[0] = _lift_above_table(r + t * v, cushion, R)
 
         return ball
 
@@ -172,17 +176,64 @@ class CoreBallCCushionCollision(ABC):
 def _apply_fallback_positioning_linear(
     ball: Ball, cushion: LinearCushionSegment, spacer: float
 ) -> Ball:
-    """Place the ball at R + spacer from the cushion along the geometric normal.
+    """Place the ball at R + spacer from the cushion line along the 3D perpendicular.
 
     Used when the ball is nontranslating (no velocity to trace back along) or
     when the velocity-based correction would produce an excessive displacement.
     """
+    R = ball.params.R
     c = ptmath.point_on_line_closest_to_point(cushion.p1, cushion.p2, ball.state.rvw[0])
-    c[2] = ball.state.rvw[0, 2]
     direction = ptmath.unit_vector(ball.state.rvw[0] - c)
-    ball.state.rvw[0] = c + (ball.params.R + spacer) * direction
+    candidate = c + (R + spacer) * direction
+    ball.state.rvw[0] = _lift_above_table(candidate, cushion, R)
 
     return ball
+
+
+def _lift_above_table(
+    pos: np.ndarray,
+    cushion: LinearCushionSegment,
+    R: float,
+) -> np.ndarray:
+    """Rotate ``pos`` around the cushion axis until ``pos[2] == R``, preserving its
+    distance from the cushion line. Returns ``pos`` unchanged if ``pos[2] >= R``.
+
+    Constrains a candidate ball position to the table (z = R) when the 3D
+    perpendicular from the cushion line would otherwise place it below. The ball
+    traces a circle around the cushion axis at the existing arm length, and is
+    moved along that circle to the intersection with the z = R plane that is on
+    the same side as the original position.
+
+    Degenerate cases (cushion axis nearly aligned with z, or arm too short to
+    reach z = R) return ``pos`` unchanged.
+    """
+    if pos[2] >= R:
+        return pos
+
+    c = ptmath.point_on_line_closest_to_point(cushion.p1, cushion.p2, pos)
+    arm = pos - c
+    arm_len = ptmath.norm3d(arm)
+    direction = arm / arm_len
+
+    u = cushion.unit_axis
+    u_z = u[2]
+    sin_lat = np.sqrt(1.0 - u_z * u_z)
+    if sin_lat < 1e-12:
+        return pos
+
+    z_in_plane_unit = np.array(
+        [-u[0] * u_z, -u[1] * u_z, 1.0 - u_z * u_z], dtype=np.float64
+    ) / sin_lat
+    h_hat = np.cross(u, z_in_plane_unit)
+
+    a = (R - c[2]) / arm_len / sin_lat
+    if abs(a) > 1.0:
+        return pos
+
+    b = float(np.sign(np.dot(direction, h_hat))) * np.sqrt(1.0 - a * a)
+    new_direction = a * z_in_plane_unit + b * h_hat
+
+    return c + arm_len * new_direction
 
 
 def _apply_fallback_positioning_circular(

--- a/pooltool/physics/resolve/ball_cushion/core.py
+++ b/pooltool/physics/resolve/ball_cushion/core.py
@@ -159,7 +159,7 @@ class CoreBallCCushionCollision(ABC):
         if ptmath.norm3d(t * v) > FALLBACK_DISPLACEMENT_FACTOR * spacer:
             return _apply_fallback_positioning_circular(ball, cushion, spacer)
 
-        ball.state.rvw[0] = _clamp_to_table(r + t * v, R)
+        ball.state.rvw[0] = r + t * v
 
         return ball
 
@@ -192,19 +192,6 @@ def _apply_fallback_positioning_linear(
     )
 
     return ball
-
-
-def _clamp_to_table(pos: np.ndarray, R: float) -> np.ndarray:
-    """Raise ``pos[2]`` to ``R`` if below, leave unchanged otherwise.
-
-    For vertical-axis cushions (the current circular cushion model), this preserves
-    distance from the cushion axis since the axis runs along z.
-    """
-    if pos[2] >= R:
-        return pos
-    new_pos = pos.copy()
-    new_pos[2] = R
-    return new_pos
 
 
 def _constrain_to_table(

--- a/pooltool/physics/resolve/ball_cushion/core.py
+++ b/pooltool/physics/resolve/ball_cushion/core.py
@@ -89,7 +89,6 @@ class CoreBallLCushionCollision(ABC):
             return _apply_fallback_positioning_linear(ball, cushion, spacer)
 
         ball.state.rvw[0] = r + t * v
-        ball = _guard_against_z_drift(ball)
 
         return ball
 
@@ -152,7 +151,6 @@ class CoreBallCCushionCollision(ABC):
             return _apply_fallback_positioning_circular(ball, cushion, spacer)
 
         ball.state.rvw[0] = r + t * v
-        ball = _guard_against_z_drift(ball)
 
         return ball
 
@@ -168,15 +166,6 @@ class CoreBallCCushionCollision(ABC):
         return self.solve(ball, cushion)  # type: ignore
 
 
-def _guard_against_z_drift(ball: Ball) -> Ball:
-    if ball.state.rvw[0, 2] < ball.params.R:
-        ball.state.rvw[0, 2] = ball.params.R
-    if ball.state.rvw[0, 2] > ball.params.R and ball.state.s != const.airborne:
-        ball.state.rvw[0, 2] = ball.params.R
-
-    return ball
-
-
 def _apply_fallback_positioning_linear(
     ball: Ball, cushion: LinearCushionSegment, spacer: float
 ) -> Ball:
@@ -190,7 +179,7 @@ def _apply_fallback_positioning_linear(
     direction = ptmath.unit_vector(ball.state.rvw[0] - c)
     ball.state.rvw[0] = c + (ball.params.R + spacer) * direction
 
-    return _guard_against_z_drift(ball)
+    return ball
 
 
 def _apply_fallback_positioning_circular(
@@ -205,4 +194,4 @@ def _apply_fallback_positioning_circular(
     direction = ptmath.unit_vector(ball.state.rvw[0] - c)
     ball.state.rvw[0] = c + (ball.params.R + cushion.radius + spacer) * direction
 
-    return _guard_against_z_drift(ball)
+    return ball

--- a/pooltool/physics/resolve/ball_cushion/core.py
+++ b/pooltool/physics/resolve/ball_cushion/core.py
@@ -73,10 +73,11 @@ class CoreBallLCushionCollision(ABC):
         cushion line equals ``R + nose_radius + spacer``, then moves the ball to
         ``r + t * v``. The smallest-magnitude real root is chosen.
 
-        If the ball is nontranslating or the displacement would exceed
-        FALLBACK_DISPLACEMENT_FACTOR * spacer (e.g. on a near-grazing trajectory,
-        or when the ball's velocity is parallel to the cushion axis), falls back to
-        positioning along the perpendicular from the cushion line.
+        If the ball is nontranslating, if the quadratic has no real root (which
+        happens when the velocity is parallel to the cushion axis, leaving no
+        perpendicular component to travel along), or if the displacement would exceed
+        FALLBACK_DISPLACEMENT_FACTOR * spacer (e.g. on a near-grazing trajectory),
+        falls back to positioning along the perpendicular from the cushion line.
         """
         r = ball.state.rvw[0]
         v = ball.state.rvw[1]
@@ -98,6 +99,9 @@ class CoreBallLCushionCollision(ABC):
 
         roots_complex = ptmath.roots.quadratic.solve(alpha, beta, gamma)
         t = ptmath.roots.get_real_smallest_magnitude_root(roots_complex)
+
+        if not np.isfinite(t):
+            return _apply_fallback_positioning_linear(ball, cushion, spacer)
 
         if ptmath.norm3d(t * v) > FALLBACK_DISPLACEMENT_FACTOR * spacer:
             return _apply_fallback_positioning_linear(ball, cushion, spacer)
@@ -212,7 +216,9 @@ def _constrain_to_table(
     For airborne balls, the constraint is ``z >= R``: only lift when below R.
 
     The rotation preserves the arm length (distance from cushion line) and keeps the
-    ball on its original side around the axis.
+    ball on its original side around the axis. When the ball sits exactly on the
+    vertical through the cushion axis it has no side to preserve, and the positive
+    side is chosen arbitrarily.
     """
     if airborne and pos[2] >= R:
         return pos
@@ -230,7 +236,8 @@ def _constrain_to_table(
     h_hat = np.array([u[1], -u[0], 0.0])
 
     a = (R - c[2]) / arm_len
-    b = np.sign(np.dot(direction, h_hat)) * np.sqrt(1.0 - a * a)
+    side = 1.0 if np.dot(direction, h_hat) >= 0 else -1.0
+    b = side * np.sqrt(1.0 - a * a)
     new_direction = a * z_hat + b * h_hat
 
     return c + arm_len * new_direction

--- a/pooltool/ptmath/roots/__init__.py
+++ b/pooltool/ptmath/roots/__init__.py
@@ -3,12 +3,14 @@ import pooltool.ptmath.roots.quartic as quartic
 from pooltool.ptmath.roots.core import (
     get_real_positive_smallest_root,
     get_real_positive_smallest_roots,
+    get_real_smallest_magnitude_root,
     is_real_number,
 )
 
 __all__ = [
     "get_real_positive_smallest_root",
     "get_real_positive_smallest_roots",
+    "get_real_smallest_magnitude_root",
     "is_real_number",
     "quadratic",
     "quartic",

--- a/pooltool/ptmath/roots/core.py
+++ b/pooltool/ptmath/roots/core.py
@@ -76,6 +76,16 @@ def get_real_smallest_magnitude_root(
 ) -> float:
     """Returns the real root with smallest magnitude (closest to zero) from a set of roots.
 
+    Args:
+        roots:
+            A 1D array of n polynomial roots.
+        abs_or_rel_cutoff:
+            See :func:`get_real_positive_smallest_root`.
+        atol:
+            See :func:`get_real_positive_smallest_root`.
+        rtol:
+            See :func:`get_real_positive_smallest_root`.
+
     Returns:
         The real root with smallest absolute value. If no real root exists, returns
         ``np.inf``.
@@ -85,22 +95,10 @@ def get_real_smallest_magnitude_root(
 
     for i in range(len(roots)):
         root = roots[i]
-        root_real = root.real
-        root_imag = root.imag
+        real_mag = abs(root.real)
 
-        imag_mag = abs(root_imag)
-        real_mag = abs(root_real)
-
-        is_real = False
-        if real_mag > abs_or_rel_cutoff:
-            is_real = imag_mag < atol
-        elif real_mag > 0:
-            is_real = (imag_mag / real_mag) < rtol
-        else:
-            is_real = imag_mag == 0.0
-
-        if is_real and real_mag < min_mag:
-            min_root = root_real
+        if is_real_number(root, abs_or_rel_cutoff, rtol, atol) and real_mag < min_mag:
+            min_root = root.real
             min_mag = real_mag
 
     return min_root

--- a/pooltool/ptmath/roots/core.py
+++ b/pooltool/ptmath/roots/core.py
@@ -68,6 +68,45 @@ def get_real_positive_smallest_root(
 
 
 @jit(nopython=True, cache=const.use_numba_cache)
+def get_real_smallest_magnitude_root(
+    roots: NDArray[np.complex128],
+    abs_or_rel_cutoff: float = 1e-3,
+    rtol: float = 1e-3,
+    atol: float = 1e-9,
+) -> float:
+    """Returns the real root with smallest magnitude (closest to zero) from a set of roots.
+
+    Returns:
+        The real root with smallest absolute value. If no real root exists, returns
+        ``np.inf``.
+    """
+    min_root = np.inf
+    min_mag = np.inf
+
+    for i in range(len(roots)):
+        root = roots[i]
+        root_real = root.real
+        root_imag = root.imag
+
+        imag_mag = abs(root_imag)
+        real_mag = abs(root_real)
+
+        is_real = False
+        if real_mag > abs_or_rel_cutoff:
+            is_real = imag_mag < atol
+        elif real_mag > 0:
+            is_real = (imag_mag / real_mag) < rtol
+        else:
+            is_real = imag_mag == 0.0
+
+        if is_real and real_mag < min_mag:
+            min_root = root_real
+            min_mag = real_mag
+
+    return min_root
+
+
+@jit(nopython=True, cache=const.use_numba_cache)
 def get_real_positive_smallest_roots(
     roots: NDArray[np.complex128],
     abs_or_rel_cutoff: float = 1e-3,

--- a/tests/physics/resolve/ball_cushion/conftest.py
+++ b/tests/physics/resolve/ball_cushion/conftest.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pytest
+
+from pooltool.objects import (
+    CircularCushionSegment,
+    LinearCushionSegment,
+    PocketTableSpecs,
+)
+
+
+@pytest.fixture
+def cushion() -> LinearCushionSegment:
+    specs = PocketTableSpecs()
+
+    return LinearCushionSegment(
+        "cushion",
+        p1=np.array([0, -1, specs.cushion_height], dtype=np.float64),
+        p2=np.array([0, +1, specs.cushion_height], dtype=np.float64),
+        nose_radius=specs.cushion_nose_radius,
+    )
+
+
+@pytest.fixture
+def cushion_circular() -> CircularCushionSegment:
+    h = PocketTableSpecs().cushion_height
+
+    return CircularCushionSegment(
+        "pocket_cushion",
+        center=np.array([0.0, 0.0, h], dtype=np.float64),
+        radius=0.01,
+    )

--- a/tests/physics/resolve/ball_cushion/test_ball_cushion.py
+++ b/tests/physics/resolve/ball_cushion/test_ball_cushion.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from pooltool import physics, ptmath
-from pooltool.constants import sliding, stationary
+from pooltool.constants import airborne, sliding, stationary
 from pooltool.objects import (
     Ball,
     BallParams,
@@ -475,3 +475,48 @@ def test_make_kiss_fallback_boundary_circular(
     assert ptmath.norm3d(ball.state.rvw[0] - c) == pytest.approx(
         R + cushion_circular.radius + spacer, abs=1e-12
     )
+
+
+def test_make_kiss_z_clamp_linear(cushion_yaxis: LinearCushionSegment) -> None:
+    """Non-airborne balls end at z = R; airborne balls end at max(z_in, R)."""
+    R = BallParams.default().R
+    model = ball_lcushion_models[BallLCushionModel.MATHAVAN_2010]()
+
+    for z_in in [R - 1e-7, R, R + 1e-7]:
+        ball = Ball("cue")
+        ball.state.rvw[0] = [-R, 0, z_in]
+        ball.state.rvw[1] = [1.0, 0.0, 0.0]
+        ball.state.s = sliding
+        model.make_kiss(ball, cushion_yaxis)
+        assert ball.state.rvw[0, 2] == R
+
+    for z_in in [R - 1e-7, R, R + 0.05]:
+        ball = Ball("cue")
+        ball.state.rvw[0] = [-R, 0, z_in]
+        ball.state.rvw[1] = [1.0, 0.0, 0.0]
+        ball.state.s = airborne
+        model.make_kiss(ball, cushion_yaxis)
+        assert ball.state.rvw[0, 2] == max(z_in, R)
+
+
+def test_make_kiss_z_clamp_circular(cushion_circular: CircularCushionSegment) -> None:
+    """Non-airborne balls end at z = R; airborne balls end at max(z_in, R)."""
+    R = BallParams.default().R
+    dist = R + cushion_circular.radius
+    model = ball_ccushion_models[BallCCushionModel.MATHAVAN_2010]()
+
+    for z_in in [R - 1e-7, R, R + 1e-7]:
+        ball = Ball("cue")
+        ball.state.rvw[0] = [dist, 0.0, z_in]
+        ball.state.rvw[1] = [-1.0, 0.0, 0.0]
+        ball.state.s = sliding
+        model.make_kiss(ball, cushion_circular)
+        assert ball.state.rvw[0, 2] == R
+
+    for z_in in [R - 1e-7, R, R + 0.05]:
+        ball = Ball("cue")
+        ball.state.rvw[0] = [dist, 0.0, z_in]
+        ball.state.rvw[1] = [-1.0, 0.0, 0.0]
+        ball.state.s = airborne
+        model.make_kiss(ball, cushion_circular)
+        assert ball.state.rvw[0, 2] == max(z_in, R)

--- a/tests/physics/resolve/ball_cushion/test_ball_cushion.py
+++ b/tests/physics/resolve/ball_cushion/test_ball_cushion.py
@@ -1,49 +1,11 @@
 import numpy as np
 import pytest
 
-from pooltool import physics, ptmath
-from pooltool.constants import airborne, sliding, stationary
-from pooltool.objects import (
-    Ball,
-    BallParams,
-    CircularCushionSegment,
-    LinearCushionSegment,
-    PocketTableSpecs,
-)
-from pooltool.physics.resolve.ball_cushion import (
-    BallLCushionModel,
-    ball_ccushion_models,
-    ball_lcushion_models,
-)
-from pooltool.physics.resolve.ball_cushion.core import (
-    BallLCushionCollisionStrategy,
-    CoreBallCCushionCollision,
-    CoreBallLCushionCollision,
-)
-from pooltool.physics.resolve.models import BallCCushionModel
-
-
-@pytest.fixture
-def cushion_yaxis():
-    specs = PocketTableSpecs()
-
-    return LinearCushionSegment(
-        "cushion",
-        p1=np.array([0, -1, specs.cushion_height], dtype=np.float64),
-        p2=np.array([0, +1, specs.cushion_height], dtype=np.float64),
-        nose_radius=specs.cushion_nose_radius,
-    )
-
-
-@pytest.fixture
-def cushion_circular():
-    h = PocketTableSpecs().cushion_height
-
-    return CircularCushionSegment(
-        "pocket_cushion",
-        center=np.array([0.0, 0.0, h], dtype=np.float64),
-        radius=0.01,
-    )
+from pooltool import physics
+from pooltool.constants import sliding
+from pooltool.objects import Ball, BallParams, LinearCushionSegment
+from pooltool.physics.resolve.ball_cushion import ball_lcushion_models
+from pooltool.physics.resolve.ball_cushion.core import BallLCushionCollisionStrategy
 
 
 @pytest.mark.parametrize(
@@ -52,7 +14,7 @@ def cushion_circular():
 )
 @pytest.mark.parametrize("theta", np.linspace(1, 89, 10))
 def test_ball_cushion_energy(
-    cushion_yaxis: LinearCushionSegment,
+    cushion: LinearCushionSegment,
     model_cls: type[BallLCushionCollisionStrategy],
     theta: float,
 ) -> None:
@@ -78,7 +40,7 @@ def test_ball_cushion_energy(
 
     # Resolve physics
     model = model_cls()
-    ball_after, _ = model.resolve(ball=ball, cushion=cushion_yaxis, inplace=False)
+    ball_after, _ = model.resolve(ball=ball, cushion=cushion, inplace=False)
 
     final_energy = physics.get_ball_energy(
         ball_after.state.rvw,
@@ -98,7 +60,7 @@ def test_ball_cushion_energy(
 )
 @pytest.mark.parametrize("theta", np.linspace(-89, 89, 20))
 def test_ball_cushion_symmetry(
-    cushion_yaxis: LinearCushionSegment,
+    cushion: LinearCushionSegment,
     model_cls: type[BallLCushionCollisionStrategy],
     theta: float,
 ) -> None:
@@ -130,8 +92,8 @@ def test_ball_cushion_symmetry(
 
     # Resolve physics
     model = model_cls()
-    ball_after, _ = model.resolve(ball=ball, cushion=cushion_yaxis, inplace=False)
-    other_after, _ = model.resolve(ball=other, cushion=cushion_yaxis, inplace=False)
+    ball_after, _ = model.resolve(ball=ball, cushion=cushion, inplace=False)
+    other_after, _ = model.resolve(ball=other, cushion=cushion, inplace=False)
 
     # The velocities have been updated
     assert not np.array_equal(ball.state.rvw[1], ball_after.state.rvw[1])
@@ -144,379 +106,3 @@ def test_ball_cushion_symmetry(
 
     # Y-velocities are reflected
     assert np.isclose(ball_after.state.rvw[1, 1], -other_after.state.rvw[1, 1])
-
-
-def _get_linear_spacer() -> float:
-    class _Probe(CoreBallLCushionCollision):
-        def solve(self, ball, cushion):
-            return ball, cushion
-
-    probe = _Probe()
-    R = BallParams.default().R
-    specs = PocketTableSpecs()
-    cushion = LinearCushionSegment(
-        "probe",
-        p1=np.array([0, -1, specs.cushion_height], dtype=np.float64),
-        p2=np.array([0, +1, specs.cushion_height], dtype=np.float64),
-        nose_radius=specs.cushion_nose_radius,
-    )
-    ball = Ball("probe")
-    ball.state.rvw[0] = [-R, 0, R]
-    ball.state.rvw[1] = [1.0, 0.0, 0.0]
-    ball.state.s = sliding
-
-    probe.make_kiss(ball, cushion)
-    pos_after = ball.state.rvw[0]
-
-    c = ptmath.point_on_line_closest_to_point(cushion.p1, cushion.p2, pos_after)
-    c[2] = pos_after[2]
-    return ptmath.norm3d(pos_after - c) - R
-
-
-def _get_circular_spacer() -> float:
-    class _Probe(CoreBallCCushionCollision):
-        def solve(self, ball, cushion):
-            return ball, cushion
-
-    probe = _Probe()
-    R = BallParams.default().R
-    h = PocketTableSpecs().cushion_height
-    cushion = CircularCushionSegment(
-        "probe",
-        center=np.array([0.0, 0.0, h], dtype=np.float64),
-        radius=0.01,
-    )
-    ball = Ball("probe")
-    dist = R + cushion.radius
-    ball.state.rvw[0] = [dist, 0.0, R]
-    ball.state.rvw[1] = [-1.0, 0.0, 0.0]
-    ball.state.s = sliding
-
-    probe.make_kiss(ball, cushion)
-    c = np.array([cushion.center[0], cushion.center[1], ball.state.rvw[0, 2]])
-    return ptmath.norm3d(ball.state.rvw[0] - c) - R - cushion.radius
-
-
-@pytest.mark.parametrize("theta", [15, 30, 45, 60, 75])
-def test_make_kiss_displacement_along_velocity_linear(
-    cushion_yaxis: LinearCushionSegment, theta: float
-) -> None:
-    R = BallParams.default().R
-    rads = np.radians(theta)
-    vel = np.array([np.cos(rads), np.sin(rads), 0.0])
-
-    ball = Ball("cue")
-    ball.state.rvw[0] = [-R, 0, R]
-    ball.state.rvw[1] = vel
-    ball.state.s = sliding
-
-    pos_before = ball.state.rvw[0].copy()
-
-    model = ball_lcushion_models[BallLCushionModel.MATHAVAN_2010]()
-    model.make_kiss(ball, cushion_yaxis)
-
-    displacement = ball.state.rvw[0] - pos_before
-    cross = np.cross(displacement, vel)
-    assert np.allclose(cross, 0, atol=1e-10), (
-        f"Displacement {displacement} is not parallel to velocity {vel}"
-    )
-
-
-@pytest.mark.parametrize("theta", [15, 30, 45, 60, 75])
-def test_make_kiss_displacement_along_velocity_circular(
-    cushion_circular: CircularCushionSegment, theta: float
-) -> None:
-    R = BallParams.default().R
-    dist = R + cushion_circular.radius
-    rads = np.radians(theta)
-
-    ball = Ball("cue")
-    ball.state.rvw[0] = [dist * np.cos(rads), dist * np.sin(rads), R]
-    vel_dir = (
-        np.array([cushion_circular.center[0], cushion_circular.center[1], R])
-        - ball.state.rvw[0]
-    )
-    vel_dir[2] = 0.0
-    vel_dir = vel_dir / np.linalg.norm(vel_dir)
-    perp = np.array([-vel_dir[1], vel_dir[0], 0.0])
-    vel = vel_dir + 0.3 * perp
-    vel = vel / np.linalg.norm(vel)
-
-    ball.state.rvw[1] = vel
-    ball.state.s = sliding
-
-    pos_before = ball.state.rvw[0].copy()
-
-    model = ball_ccushion_models[BallCCushionModel.MATHAVAN_2010]()
-    model.make_kiss(ball, cushion_circular)
-
-    displacement = ball.state.rvw[0] - pos_before
-    cross = np.cross(displacement, vel)
-    assert np.allclose(cross, 0, atol=1e-10), (
-        f"Displacement {displacement} is not parallel to velocity {vel}"
-    )
-
-
-@pytest.mark.parametrize("offset", [-1e-7, 0, 1e-7])
-def test_make_kiss_separation_linear(
-    cushion_yaxis: LinearCushionSegment, offset: float
-) -> None:
-    R = BallParams.default().R
-    spacer = _get_linear_spacer()
-
-    ball = Ball("cue")
-    ball.state.rvw[0] = [-(R + offset), 0, R]
-    ball.state.rvw[1] = [1.0, 0.0, 0.0]
-    ball.state.s = sliding
-
-    model = ball_lcushion_models[BallLCushionModel.MATHAVAN_2010]()
-    model.make_kiss(ball, cushion_yaxis)
-
-    c = ptmath.point_on_line_closest_to_point(
-        cushion_yaxis.p1, cushion_yaxis.p2, ball.state.rvw[0]
-    )
-    c[2] = ball.state.rvw[0, 2]
-    dist = ptmath.norm3d(ball.state.rvw[0] - c)
-
-    assert dist == pytest.approx(R + spacer, abs=1e-12)
-
-
-def test_make_kiss_separation_circular(
-    cushion_circular: CircularCushionSegment,
-) -> None:
-    R = BallParams.default().R
-    spacer = _get_circular_spacer()
-    target_dist = R + cushion_circular.radius
-
-    ball = Ball("cue")
-    ball.state.rvw[0] = [target_dist, 0.0, R]
-    ball.state.rvw[1] = [-1.0, 0.0, 0.0]
-    ball.state.s = sliding
-
-    model = ball_ccushion_models[BallCCushionModel.MATHAVAN_2010]()
-    model.make_kiss(ball, cushion_circular)
-
-    c = np.array(
-        [cushion_circular.center[0], cushion_circular.center[1], ball.state.rvw[0, 2]]
-    )
-    dist = ptmath.norm3d(ball.state.rvw[0] - c)
-
-    assert dist == pytest.approx(R + cushion_circular.radius + spacer, abs=1e-12)
-
-
-def test_make_kiss_nontranslating_linear(
-    cushion_yaxis: LinearCushionSegment,
-) -> None:
-    R = BallParams.default().R
-    spacer = _get_linear_spacer()
-
-    ball = Ball("cue")
-    ball.state.rvw[0] = [-(R - 1e-7), 0, R]
-    ball.state.rvw[1] = [0.0, 0.0, 0.0]
-    ball.state.s = stationary
-
-    pos_before = ball.state.rvw[0].copy()
-
-    model = ball_lcushion_models[BallLCushionModel.MATHAVAN_2010]()
-    model.make_kiss(ball, cushion_yaxis)
-
-    c = ptmath.point_on_line_closest_to_point(
-        cushion_yaxis.p1, cushion_yaxis.p2, ball.state.rvw[0]
-    )
-    c[2] = ball.state.rvw[0, 2]
-    dist = ptmath.norm3d(ball.state.rvw[0] - c)
-    assert dist == pytest.approx(R + spacer, abs=1e-12)
-
-    displacement = ball.state.rvw[0] - pos_before
-    normal = cushion_yaxis.get_normal_xy(ball.state.rvw[0])
-    disp_norm = displacement / np.linalg.norm(displacement)
-    assert np.allclose(np.abs(np.dot(disp_norm, normal)), 1.0, atol=1e-10)
-
-
-def test_make_kiss_nontranslating_circular(
-    cushion_circular: CircularCushionSegment,
-) -> None:
-    R = BallParams.default().R
-    spacer = _get_circular_spacer()
-    target_dist = R + cushion_circular.radius
-
-    ball = Ball("cue")
-    ball.state.rvw[0] = [target_dist - 1e-7, 0.0, R]
-    ball.state.rvw[1] = [0.0, 0.0, 0.0]
-    ball.state.s = stationary
-
-    pos_before = ball.state.rvw[0].copy()
-
-    model = ball_ccushion_models[BallCCushionModel.MATHAVAN_2010]()
-    model.make_kiss(ball, cushion_circular)
-
-    c = np.array(
-        [cushion_circular.center[0], cushion_circular.center[1], ball.state.rvw[0, 2]]
-    )
-    dist = ptmath.norm3d(ball.state.rvw[0] - c)
-    assert dist == pytest.approx(R + cushion_circular.radius + spacer, abs=1e-12)
-
-    displacement = ball.state.rvw[0] - pos_before
-    normal = cushion_circular.get_normal_xy(ball.state.rvw[0])
-    disp_norm = displacement / np.linalg.norm(displacement)
-    assert np.allclose(np.abs(np.dot(disp_norm, normal)), 1.0, atol=1e-10)
-
-
-def test_make_kiss_fallback_boundary_linear(
-    cushion_yaxis: LinearCushionSegment,
-) -> None:
-    """Test both sides of the fallback boundary for linear cushions.
-
-    For a ball at [-R, 0, R] with unit velocity at grazing angle phi from the
-    cushion surface, the velocity-based displacement is spacer / sin(phi).
-    The fallback triggers when this exceeds 5 * spacer, i.e. sin(phi) < 1/5.
-    """
-    R = BallParams.default().R
-    spacer = _get_linear_spacer()
-    model = ball_lcushion_models[BallLCushionModel.MATHAVAN_2010]()
-
-    phi = np.degrees(np.arcsin(0.2))
-    dphi = 1.0
-
-    # phi: just above boundary → velocity-based (displacement parallel to velocity)
-    ball = Ball("cue")
-    rads = np.radians(phi + dphi)
-    vel = np.array([np.sin(rads), np.cos(rads), 0.0])
-    ball.state.rvw[0] = [-R, 0, R]
-    ball.state.rvw[1] = vel
-    ball.state.s = sliding
-    pos_before = ball.state.rvw[0].copy()
-    model.make_kiss(ball, cushion_yaxis)
-    displacement = ball.state.rvw[0] - pos_before
-    cross = np.cross(displacement, vel)
-    assert np.allclose(cross, 0, atol=1e-10)
-
-    c = ptmath.point_on_line_closest_to_point(
-        cushion_yaxis.p1, cushion_yaxis.p2, ball.state.rvw[0]
-    )
-    c[2] = ball.state.rvw[0, 2]
-    assert ptmath.norm3d(ball.state.rvw[0] - c) == pytest.approx(R + spacer, abs=1e-12)
-
-    # phi - dphi: just below boundary → fallback (displacement along normal)
-    ball = Ball("cue")
-    rads = np.radians(phi - dphi)
-    vel = np.array([np.sin(rads), np.cos(rads), 0.0])
-    ball.state.rvw[0] = [-R, 0, R]
-    ball.state.rvw[1] = vel
-    ball.state.s = sliding
-    pos_before = ball.state.rvw[0].copy()
-    model.make_kiss(ball, cushion_yaxis)
-    displacement = ball.state.rvw[0] - pos_before
-    normal = cushion_yaxis.get_normal_xy(ball.state.rvw[0])
-    disp_norm = displacement / np.linalg.norm(displacement)
-    assert np.allclose(np.abs(np.dot(disp_norm, normal)), 1.0, atol=1e-10)
-
-    c = ptmath.point_on_line_closest_to_point(
-        cushion_yaxis.p1, cushion_yaxis.p2, ball.state.rvw[0]
-    )
-    c[2] = ball.state.rvw[0, 2]
-    assert ptmath.norm3d(ball.state.rvw[0] - c) == pytest.approx(R + spacer, abs=1e-12)
-
-
-def test_make_kiss_fallback_boundary_circular(
-    cushion_circular: CircularCushionSegment,
-) -> None:
-    """Test both sides of the fallback boundary for circular cushions.
-
-    For a ball at [dist, 0, R] with unit velocity at grazing angle phi from the
-    cushion tangent, the velocity-based displacement is approximately
-    spacer / sin(phi). The fallback triggers when this exceeds 5 * spacer.
-    """
-    R = BallParams.default().R
-    spacer = _get_circular_spacer()
-    dist = R + cushion_circular.radius
-    model = ball_ccushion_models[BallCCushionModel.MATHAVAN_2010]()
-
-    phi = np.degrees(np.arcsin(0.2))
-    dphi = 1.0
-
-    # phi: just above boundary → velocity-based (displacement parallel to velocity)
-    ball = Ball("cue")
-    rads = np.radians(phi + dphi)
-    vel = np.array([-np.sin(rads), np.cos(rads), 0.0])
-    ball.state.rvw[0] = [dist, 0.0, R]
-    ball.state.rvw[1] = vel
-    ball.state.s = sliding
-    pos_before = ball.state.rvw[0].copy()
-    model.make_kiss(ball, cushion_circular)
-    displacement = ball.state.rvw[0] - pos_before
-    cross = np.cross(displacement, vel)
-    assert np.allclose(cross, 0, atol=1e-10)
-
-    c = np.array(
-        [cushion_circular.center[0], cushion_circular.center[1], ball.state.rvw[0, 2]]
-    )
-    assert ptmath.norm3d(ball.state.rvw[0] - c) == pytest.approx(
-        R + cushion_circular.radius + spacer, abs=1e-12
-    )
-
-    # phi - dphi: just below boundary → fallback (displacement along radial)
-    ball = Ball("cue")
-    rads = np.radians(phi - dphi)
-    vel = np.array([-np.sin(rads), np.cos(rads), 0.0])
-    ball.state.rvw[0] = [dist, 0.0, R]
-    ball.state.rvw[1] = vel
-    ball.state.s = sliding
-    pos_before = ball.state.rvw[0].copy()
-    model.make_kiss(ball, cushion_circular)
-    displacement = ball.state.rvw[0] - pos_before
-    normal = cushion_circular.get_normal_xy(ball.state.rvw[0])
-    disp_norm = displacement / np.linalg.norm(displacement)
-    assert np.allclose(np.abs(np.dot(disp_norm, normal)), 1.0, atol=1e-10)
-
-    c = np.array(
-        [cushion_circular.center[0], cushion_circular.center[1], ball.state.rvw[0, 2]]
-    )
-    assert ptmath.norm3d(ball.state.rvw[0] - c) == pytest.approx(
-        R + cushion_circular.radius + spacer, abs=1e-12
-    )
-
-
-def test_make_kiss_z_clamp_linear(cushion_yaxis: LinearCushionSegment) -> None:
-    """Non-airborne balls end at z = R; airborne balls end at max(z_in, R)."""
-    R = BallParams.default().R
-    model = ball_lcushion_models[BallLCushionModel.MATHAVAN_2010]()
-
-    for z_in in [R - 1e-7, R, R + 1e-7]:
-        ball = Ball("cue")
-        ball.state.rvw[0] = [-R, 0, z_in]
-        ball.state.rvw[1] = [1.0, 0.0, 0.0]
-        ball.state.s = sliding
-        model.make_kiss(ball, cushion_yaxis)
-        assert ball.state.rvw[0, 2] == R
-
-    for z_in in [R - 1e-7, R, R + 0.05]:
-        ball = Ball("cue")
-        ball.state.rvw[0] = [-R, 0, z_in]
-        ball.state.rvw[1] = [1.0, 0.0, 0.0]
-        ball.state.s = airborne
-        model.make_kiss(ball, cushion_yaxis)
-        assert ball.state.rvw[0, 2] == max(z_in, R)
-
-
-def test_make_kiss_z_clamp_circular(cushion_circular: CircularCushionSegment) -> None:
-    """Non-airborne balls end at z = R; airborne balls end at max(z_in, R)."""
-    R = BallParams.default().R
-    dist = R + cushion_circular.radius
-    model = ball_ccushion_models[BallCCushionModel.MATHAVAN_2010]()
-
-    for z_in in [R - 1e-7, R, R + 1e-7]:
-        ball = Ball("cue")
-        ball.state.rvw[0] = [dist, 0.0, z_in]
-        ball.state.rvw[1] = [-1.0, 0.0, 0.0]
-        ball.state.s = sliding
-        model.make_kiss(ball, cushion_circular)
-        assert ball.state.rvw[0, 2] == R
-
-    for z_in in [R - 1e-7, R, R + 0.05]:
-        ball = Ball("cue")
-        ball.state.rvw[0] = [dist, 0.0, z_in]
-        ball.state.rvw[1] = [-1.0, 0.0, 0.0]
-        ball.state.s = airborne
-        model.make_kiss(ball, cushion_circular)
-        assert ball.state.rvw[0, 2] == max(z_in, R)

--- a/tests/physics/resolve/ball_cushion/test_make_kiss.py
+++ b/tests/physics/resolve/ball_cushion/test_make_kiss.py
@@ -1,0 +1,284 @@
+import numpy as np
+import pytest
+
+from pooltool import ptmath
+from pooltool.constants import MIN_DIST, sliding, stationary
+from pooltool.objects import (
+    Ball,
+    BallParams,
+    CircularCushionSegment,
+    LinearCushionSegment,
+)
+from pooltool.physics.resolve.ball_cushion import (
+    ball_ccushion_models,
+    ball_lcushion_models,
+)
+from pooltool.physics.resolve.ball_cushion.core import FALLBACK_DISPLACEMENT_FACTOR
+from pooltool.physics.resolve.models import BallCCushionModel, BallLCushionModel
+
+GRAZING_THRESHOLD_INCIDENCE_DEG = float(
+    np.degrees(np.arccos(1.0 / FALLBACK_DISPLACEMENT_FACTOR))
+)
+"""Incidence angle (from cushion normal, degrees) above which make_kiss falls back.
+
+Derived from FALLBACK_DISPLACEMENT_FACTOR: the velocity-based displacement is
+``spacer / cos(incidence)``, so fallback triggers when
+``cos(incidence) < 1 / FALLBACK_DISPLACEMENT_FACTOR``.
+"""
+
+
+def ball_at(
+    pos: tuple[float, float, float],
+    vel: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    s: int = sliding,
+) -> Ball:
+    """Create a Ball with given position, velocity, and motion state."""
+    ball = Ball("cue")
+    ball.state.rvw[0] = pos
+    ball.state.rvw[1] = vel
+    ball.state.s = s
+    return ball
+
+
+def xy_dist_to_cushion_axis(ball: Ball, cushion: LinearCushionSegment) -> float:
+    """XY-distance from ball center to the cushion axis (line through p1, p2)."""
+    pos = ball.state.rvw[0]
+    c = ptmath.point_on_line_closest_to_point(cushion.p1, cushion.p2, pos)
+    c[2] = pos[2]
+    return ptmath.norm3d(pos - c)
+
+
+def xyz_dist_to_cushion_axis(ball: Ball, cushion: LinearCushionSegment) -> float:
+    """3D-distance from ball center to the cushion axis (line through p1, p2)."""
+    pos = ball.state.rvw[0]
+    c = ptmath.point_on_line_closest_to_point(cushion.p1, cushion.p2, pos)
+    return ptmath.norm3d(pos - c)
+
+
+def xy_dist_to_cushion_center(ball: Ball, cushion: CircularCushionSegment) -> float:
+    """XY-distance from ball center to the cushion center."""
+    pos = ball.state.rvw[0]
+    c = np.array([cushion.center[0], cushion.center[1], pos[2]])
+    return ptmath.norm3d(pos - c)
+
+
+def make_kiss_linear(ball: Ball, cushion: LinearCushionSegment) -> None:
+    """Run make_kiss (arbitrarily uses Mathavan model)"""
+    ball_lcushion_models[BallLCushionModel.MATHAVAN_2010]().make_kiss(ball, cushion)
+
+
+def make_kiss_circular(ball: Ball, cushion: CircularCushionSegment) -> None:
+    """Run make_kiss (arbitrarily uses Mathavan model)"""
+    ball_ccushion_models[BallCCushionModel.MATHAVAN_2010]().make_kiss(ball, cushion)
+
+
+def assert_displaced_along_velocity(ball_before: Ball, ball: Ball) -> None:
+    """Assert ball's displacement is parallel to its pre-kiss velocity."""
+    displacement = ball.state.rvw[0] - ball_before.state.rvw[0]
+    vel = ball_before.state.rvw[1]
+    cross = np.cross(displacement, vel)
+    assert np.allclose(cross, 0, atol=1e-10), (
+        f"Expected displacement parallel to velocity, "
+        f"got displacement={displacement}, vel={vel}"
+    )
+
+
+def assert_displaced_along_normal(
+    ball_before: Ball,
+    ball: Ball,
+    cushion: LinearCushionSegment | CircularCushionSegment,
+) -> None:
+    """Assert ball's displacement is along the cushion normal."""
+    displacement = ball.state.rvw[0] - ball_before.state.rvw[0]
+    normal = cushion.get_normal_xy(ball.state.rvw[0])
+    disp_norm = displacement / np.linalg.norm(displacement)
+    assert np.allclose(np.abs(np.dot(disp_norm, normal)), 1.0, atol=1e-10), (
+        f"Expected displacement along normal, "
+        f"got displacement={displacement}, normal={normal}"
+    )
+
+
+# -----------------------
+
+
+@pytest.mark.parametrize(
+    "incidence_angle_deg",
+    [
+        65,
+        70,
+        75,
+        GRAZING_THRESHOLD_INCIDENCE_DEG - 0.001,
+    ],
+)
+def test_velocity_branch(
+    cushion: LinearCushionSegment,
+    incidence_angle_deg: float,
+) -> None:
+    """Below the grazing threshold, displacement is aligned with velocity."""
+    R = BallParams.default().R
+    rads = np.radians(incidence_angle_deg)
+    vel = (np.cos(rads), np.sin(rads), 0.0)
+    ball = ball_at((-R, 0, R), vel)
+    ball_before = ball.copy()
+
+    make_kiss_linear(ball, cushion)
+
+    assert xy_dist_to_cushion_axis(ball, cushion) == pytest.approx(
+        R + MIN_DIST, abs=1e-12
+    )
+    assert_displaced_along_velocity(ball_before, ball)
+
+
+@pytest.mark.parametrize(
+    "incidence_angle_deg",
+    [
+        65,
+        70,
+        75,
+        GRAZING_THRESHOLD_INCIDENCE_DEG - 0.05,
+    ],
+)
+def test_velocity_branch_circular(
+    cushion_circular: CircularCushionSegment,
+    incidence_angle_deg: float,
+) -> None:
+    """Below the grazing threshold, displacement is aligned with velocity."""
+    R = BallParams.default().R
+    dist = R + cushion_circular.radius
+    rads = np.radians(incidence_angle_deg)
+    vel = (-np.cos(rads), np.sin(rads), 0.0)
+    ball = ball_at((dist, 0, R), vel)
+    ball_before = ball.copy()
+
+    make_kiss_circular(ball, cushion_circular)
+
+    assert xy_dist_to_cushion_center(ball, cushion_circular) == pytest.approx(
+        dist + MIN_DIST, abs=1e-12
+    )
+    assert_displaced_along_velocity(ball_before, ball)
+
+
+@pytest.mark.parametrize(
+    "incidence_angle_deg",
+    [
+        GRAZING_THRESHOLD_INCIDENCE_DEG + 0.001,
+        80,
+        85,
+        89,
+    ],
+)
+def test_fallback_branch(
+    cushion: LinearCushionSegment,
+    incidence_angle_deg: float,
+) -> None:
+    """Above the grazing threshold, displacement is aligned with the cushion normal."""
+    R = BallParams.default().R
+    rads = np.radians(incidence_angle_deg)
+    vel = (np.cos(rads), np.sin(rads), 0.0)
+    ball = ball_at((-R, 0, R), vel)
+    ball_before = ball.copy()
+
+    make_kiss_linear(ball, cushion)
+
+    assert xy_dist_to_cushion_axis(ball, cushion) == pytest.approx(
+        R + MIN_DIST, abs=1e-12
+    )
+    assert_displaced_along_normal(ball_before, ball, cushion)
+
+
+@pytest.mark.parametrize(
+    "incidence_angle_deg",
+    [
+        GRAZING_THRESHOLD_INCIDENCE_DEG + 0.05,
+        80,
+        85,
+        89,
+    ],
+)
+def test_fallback_branch_circular(
+    cushion_circular: CircularCushionSegment,
+    incidence_angle_deg: float,
+) -> None:
+    """Above the grazing threshold, displacement is aligned with the cushion normal."""
+    R = BallParams.default().R
+    dist = R + cushion_circular.radius
+    rads = np.radians(incidence_angle_deg)
+    vel = (-np.cos(rads), np.sin(rads), 0.0)
+    ball = ball_at((dist, 0, R), vel)
+    ball_before = ball.copy()
+
+    make_kiss_circular(ball, cushion_circular)
+
+    assert xy_dist_to_cushion_center(ball, cushion_circular) == pytest.approx(
+        dist + MIN_DIST, abs=1e-12
+    )
+    assert_displaced_along_normal(ball_before, ball, cushion_circular)
+
+
+@pytest.mark.parametrize("offset", [-1e-7, 0, 1e-7])
+def test_head_on_lands_at_promised_separation(
+    cushion: LinearCushionSegment, offset: float
+) -> None:
+    """Head-on approach lands at exactly R + MIN_DIST regardless of small initial offset."""
+    R = BallParams.default().R
+    ball = ball_at((-(R + offset), 0, R), (1.0, 0.0, 0.0))
+
+    make_kiss_linear(ball, cushion)
+
+    assert ball.state.rvw[0, 0] == pytest.approx(-(R + MIN_DIST), abs=1e-12)
+    assert xy_dist_to_cushion_axis(ball, cushion) == pytest.approx(
+        R + MIN_DIST, abs=1e-12
+    )
+
+
+@pytest.mark.parametrize("offset", [-1e-7, 0, 1e-7])
+def test_head_on_lands_at_promised_separation_circular(
+    cushion_circular: CircularCushionSegment, offset: float
+) -> None:
+    """Head-on approach lands at exactly R + r + MIN_DIST from cushion center, regardless of small initial offset."""
+    R = BallParams.default().R
+    target = R + cushion_circular.radius + MIN_DIST
+    ball = ball_at((target + offset, 0, R), (-1.0, 0.0, 0.0))
+
+    make_kiss_circular(ball, cushion_circular)
+
+    assert ball.state.rvw[0, 0] == pytest.approx(target, abs=1e-12)
+    assert xy_dist_to_cushion_center(ball, cushion_circular) == pytest.approx(
+        target, abs=1e-12
+    )
+
+
+def test_stationary_overlapping_uses_fallback(
+    cushion: LinearCushionSegment,
+) -> None:
+    """A stationary, slightly-overlapping ball is pushed along the normal to R + MIN_DIST."""
+    R = BallParams.default().R
+    ball = ball_at((-(R - 1e-7), 0, R), s=stationary)
+    ball_before = ball.copy()
+
+    make_kiss_linear(ball, cushion)
+
+    assert xy_dist_to_cushion_axis(ball, cushion) == pytest.approx(
+        R + MIN_DIST, abs=1e-12
+    )
+    assert_displaced_along_normal(ball_before, ball, cushion)
+
+
+# -----------------------
+
+
+def test_stationary_overlapping_uses_fallback_circular(
+    cushion_circular: CircularCushionSegment,
+) -> None:
+    """A stationary, slightly-overlapping ball is pushed along the normal to the target separation."""
+    R = BallParams.default().R
+    target = R + cushion_circular.radius + MIN_DIST
+    ball = ball_at((target - 1e-7, 0, R), s=stationary)
+    ball_before = ball.copy()
+
+    make_kiss_circular(ball, cushion_circular)
+
+    assert xy_dist_to_cushion_center(ball, cushion_circular) == pytest.approx(
+        target, abs=1e-12
+    )
+    assert_displaced_along_normal(ball_before, ball, cushion_circular)

--- a/tests/physics/resolve/ball_cushion/test_make_kiss.py
+++ b/tests/physics/resolve/ball_cushion/test_make_kiss.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from pooltool import ptmath
-from pooltool.constants import MIN_DIST, sliding, stationary
+from pooltool.constants import MIN_DIST, airborne, sliding, stationary
 from pooltool.objects import (
     Ball,
     BallParams,
@@ -27,16 +27,83 @@ Derived from FALLBACK_DISPLACEMENT_FACTOR: the velocity-based displacement is
 """
 
 
-def ball_at(
-    pos: tuple[float, float, float],
+def ball_at_3d_dist(
+    cushion: LinearCushionSegment,
+    theta_deg: float,
+    penetrance: float = 0.0,
     vel: tuple[float, float, float] = (0.0, 0.0, 0.0),
     s: int = sliding,
 ) -> Ball:
-    """Create a Ball with given position, velocity, and motion state."""
+    """Place a ball in polar coordinates around the cushion line (xz-plane).
+
+    The ball is on the -x side of the cushion. Theta is the elevation angle of
+    the line from the cushion axis to the ball center, measured in the xz-plane
+    from horizontal:
+
+        theta_deg = 0   → ball at cushion height (horizontal -x direction)
+        theta_deg = +90 → ball directly above cushion (+z)
+        theta_deg = -90 → ball directly below cushion (-z)
+
+    Args:
+        theta_deg: Elevation angle of the ball position from the cushion axis (degrees).
+        penetrance: Effective dr inside the touch radius. ``penetrance = 0`` puts the
+            ball center at distance R from the cushion axis (just touching).
+            Positive values place the ball overlapping the cushion; negative values
+            place it separated.
+
+    Assumes the cushion is along the y-axis (as in the conftest fixture).
+    """
+    R = BallParams.default().R
+    h_cushion = cushion.p1[2]
+    r = R - penetrance
+    theta_rad = np.radians(theta_deg)
+    xb = -r * np.cos(theta_rad)
+    zb = h_cushion + r * np.sin(theta_rad)
+
     ball = Ball("cue")
-    ball.state.rvw[0] = pos
+    ball.state.rvw[0] = (xb, 0, zb)
     ball.state.rvw[1] = vel
     ball.state.s = s
+
+    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(r, abs=1e-12)
+
+    return ball
+
+
+def ball_on_table(
+    cushion: LinearCushionSegment,
+    penetrance: float = 0.0,
+    vel: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    s: int = sliding,
+) -> Ball:
+    """Place a ball resting on the table (z = R) at a given 3D distance from the cushion axis.
+
+    Convenient specialization of :func:`ball_at_3d_dist` for the common scenario where
+    the cushion height exceeds R (so the on-table elevation angle is awkward to express
+    in polar form).
+
+    Args:
+        penetrance: Effective dr inside the touch radius. ``penetrance = 0`` puts the
+            ball center at distance R from the cushion axis (just touching).
+            Positive values place the ball overlapping the cushion; negative values
+            place it separated.
+
+    The ball is placed on the -x side, at y = 0. Assumes the cushion is along the
+    y-axis (as in the conftest fixture).
+    """
+    R = BallParams.default().R
+    h_cushion = cushion.p1[2]
+    r = R - penetrance
+    xy_dist = float(np.sqrt(r**2 - (R - h_cushion) ** 2))
+
+    ball = Ball("cue")
+    ball.state.rvw[0] = (-xy_dist, 0, R)
+    ball.state.rvw[1] = vel
+    ball.state.s = s
+
+    assert ball.state.rvw[0, 2] == R
+    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(r, abs=1e-12)
+
     return ball
 
 
@@ -48,7 +115,7 @@ def xy_dist_to_cushion_axis(ball: Ball, cushion: LinearCushionSegment) -> float:
     return ptmath.norm3d(pos - c)
 
 
-def xyz_dist_to_cushion_axis(ball: Ball, cushion: LinearCushionSegment) -> float:
+def dist_to_cushion_axis(ball: Ball, cushion: LinearCushionSegment) -> float:
     """3D-distance from ball center to the cushion axis (line through p1, p2)."""
     pos = ball.state.rvw[0]
     c = ptmath.point_on_line_closest_to_point(cushion.p1, cushion.p2, pos)
@@ -101,184 +168,95 @@ def assert_displaced_along_normal(
 # -----------------------
 
 
-@pytest.mark.parametrize(
-    "incidence_angle_deg",
-    [
-        65,
-        70,
-        75,
-        GRAZING_THRESHOLD_INCIDENCE_DEG - 0.001,
-    ],
-)
-def test_velocity_branch(
-    cushion: LinearCushionSegment,
-    incidence_angle_deg: float,
-) -> None:
-    """Below the grazing threshold, displacement is aligned with velocity."""
-    R = BallParams.default().R
-    rads = np.radians(incidence_angle_deg)
-    vel = (np.cos(rads), np.sin(rads), 0.0)
-    ball = ball_at((-R, 0, R), vel)
-    ball_before = ball.copy()
-
-    make_kiss_linear(ball, cushion)
-
-    assert xy_dist_to_cushion_axis(ball, cushion) == pytest.approx(
-        R + MIN_DIST, abs=1e-12
-    )
-    assert_displaced_along_velocity(ball_before, ball)
-
-
-@pytest.mark.parametrize(
-    "incidence_angle_deg",
-    [
-        65,
-        70,
-        75,
-        GRAZING_THRESHOLD_INCIDENCE_DEG - 0.05,
-    ],
-)
-def test_velocity_branch_circular(
-    cushion_circular: CircularCushionSegment,
-    incidence_angle_deg: float,
-) -> None:
-    """Below the grazing threshold, displacement is aligned with velocity."""
-    R = BallParams.default().R
-    dist = R + cushion_circular.radius
-    rads = np.radians(incidence_angle_deg)
-    vel = (-np.cos(rads), np.sin(rads), 0.0)
-    ball = ball_at((dist, 0, R), vel)
-    ball_before = ball.copy()
-
-    make_kiss_circular(ball, cushion_circular)
-
-    assert xy_dist_to_cushion_center(ball, cushion_circular) == pytest.approx(
-        dist + MIN_DIST, abs=1e-12
-    )
-    assert_displaced_along_velocity(ball_before, ball)
-
-
-@pytest.mark.parametrize(
-    "incidence_angle_deg",
-    [
-        GRAZING_THRESHOLD_INCIDENCE_DEG + 0.001,
-        80,
-        85,
-        89,
-    ],
-)
-def test_fallback_branch(
-    cushion: LinearCushionSegment,
-    incidence_angle_deg: float,
-) -> None:
-    """Above the grazing threshold, displacement is aligned with the cushion normal."""
-    R = BallParams.default().R
-    rads = np.radians(incidence_angle_deg)
-    vel = (np.cos(rads), np.sin(rads), 0.0)
-    ball = ball_at((-R, 0, R), vel)
-    ball_before = ball.copy()
-
-    make_kiss_linear(ball, cushion)
-
-    assert xy_dist_to_cushion_axis(ball, cushion) == pytest.approx(
-        R + MIN_DIST, abs=1e-12
-    )
-    assert_displaced_along_normal(ball_before, ball, cushion)
-
-
-@pytest.mark.parametrize(
-    "incidence_angle_deg",
-    [
-        GRAZING_THRESHOLD_INCIDENCE_DEG + 0.05,
-        80,
-        85,
-        89,
-    ],
-)
-def test_fallback_branch_circular(
-    cushion_circular: CircularCushionSegment,
-    incidence_angle_deg: float,
-) -> None:
-    """Above the grazing threshold, displacement is aligned with the cushion normal."""
-    R = BallParams.default().R
-    dist = R + cushion_circular.radius
-    rads = np.radians(incidence_angle_deg)
-    vel = (-np.cos(rads), np.sin(rads), 0.0)
-    ball = ball_at((dist, 0, R), vel)
-    ball_before = ball.copy()
-
-    make_kiss_circular(ball, cushion_circular)
-
-    assert xy_dist_to_cushion_center(ball, cushion_circular) == pytest.approx(
-        dist + MIN_DIST, abs=1e-12
-    )
-    assert_displaced_along_normal(ball_before, ball, cushion_circular)
-
-
-@pytest.mark.parametrize("offset", [-1e-7, 0, 1e-7])
-def test_head_on_lands_at_promised_separation(
-    cushion: LinearCushionSegment, offset: float
-) -> None:
-    """Head-on approach lands at exactly R + MIN_DIST regardless of small initial offset."""
-    R = BallParams.default().R
-    ball = ball_at((-(R + offset), 0, R), (1.0, 0.0, 0.0))
-
-    make_kiss_linear(ball, cushion)
-
-    assert ball.state.rvw[0, 0] == pytest.approx(-(R + MIN_DIST), abs=1e-12)
-    assert xy_dist_to_cushion_axis(ball, cushion) == pytest.approx(
-        R + MIN_DIST, abs=1e-12
-    )
-
-
-@pytest.mark.parametrize("offset", [-1e-7, 0, 1e-7])
-def test_head_on_lands_at_promised_separation_circular(
-    cushion_circular: CircularCushionSegment, offset: float
-) -> None:
-    """Head-on approach lands at exactly R + r + MIN_DIST from cushion center, regardless of small initial offset."""
-    R = BallParams.default().R
-    target = R + cushion_circular.radius + MIN_DIST
-    ball = ball_at((target + offset, 0, R), (-1.0, 0.0, 0.0))
-
-    make_kiss_circular(ball, cushion_circular)
-
-    assert ball.state.rvw[0, 0] == pytest.approx(target, abs=1e-12)
-    assert xy_dist_to_cushion_center(ball, cushion_circular) == pytest.approx(
-        target, abs=1e-12
-    )
-
-
-def test_stationary_overlapping_uses_fallback(
-    cushion: LinearCushionSegment,
-) -> None:
-    """A stationary, slightly-overlapping ball is pushed along the normal to R + MIN_DIST."""
-    R = BallParams.default().R
-    ball = ball_at((-(R - 1e-7), 0, R), s=stationary)
-    ball_before = ball.copy()
-
-    make_kiss_linear(ball, cushion)
-
-    assert xy_dist_to_cushion_axis(ball, cushion) == pytest.approx(
-        R + MIN_DIST, abs=1e-12
-    )
-    assert_displaced_along_normal(ball_before, ball, cushion)
-
-
 # -----------------------
+# 3D linear behavior: cushion is a 1D line at z = cushion_height. "Touch" means
+# the ball center is at 3D distance R from that line, not just R in xy.
 
 
-def test_stationary_overlapping_uses_fallback_circular(
-    cushion_circular: CircularCushionSegment,
-) -> None:
-    """A stationary, slightly-overlapping ball is pushed along the normal to the target separation."""
+def test_3d_ball_on_table(cushion: LinearCushionSegment) -> None:
+    """Ball resting on the table (z=R), slight overlap, horizontal velocity."""
     R = BallParams.default().R
-    target = R + cushion_circular.radius + MIN_DIST
-    ball = ball_at((target - 1e-7, 0, R), s=stationary)
+    ball = ball_on_table(cushion, penetrance=1e-7, vel=(1.0, 0.0, 0.0))
     ball_before = ball.copy()
 
-    make_kiss_circular(ball, cushion_circular)
+    make_kiss_linear(ball, cushion)
 
-    assert xy_dist_to_cushion_center(ball, cushion_circular) == pytest.approx(
-        target, abs=1e-12
+    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
+        R + MIN_DIST, abs=1e-12
     )
-    assert_displaced_along_normal(ball_before, ball, cushion_circular)
+    assert_displaced_along_velocity(ball_before, ball)
+
+
+def test_3d_ball_above_cushion(cushion: LinearCushionSegment) -> None:
+    """Ball above cushion line, slight overlap, horizontal velocity."""
+    R = BallParams.default().R
+    ball = ball_at_3d_dist(cushion, theta_deg=15, penetrance=1e-7, vel=(1.0, 0.0, 0.0))
+    ball_before = ball.copy()
+
+    make_kiss_linear(ball, cushion)
+
+    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
+        R + MIN_DIST, abs=1e-12
+    )
+    assert_displaced_along_velocity(ball_before, ball)
+
+
+def test_3d_ball_above_cushion_diagonal_velocity(cushion: LinearCushionSegment) -> None:
+    """Ball above cushion line with vz != 0; displacement still along 3D velocity."""
+    R = BallParams.default().R
+    vel_unit = np.array([1.0, 0.0, -0.5]) / np.linalg.norm([1.0, 0.0, -0.5])
+    vel = (float(vel_unit[0]), float(vel_unit[1]), float(vel_unit[2]))
+    ball = ball_at_3d_dist(cushion, theta_deg=15, penetrance=1e-7, vel=vel)
+    ball_before = ball.copy()
+
+    make_kiss_linear(ball, cushion)
+
+    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
+        R + MIN_DIST, abs=1e-12
+    )
+    assert_displaced_along_velocity(ball_before, ball)
+
+
+@pytest.mark.parametrize(
+    "ball_factory",
+    [
+        pytest.param(
+            lambda c: ball_on_table(c, penetrance=1e-7, s=stationary),
+            id="stationary_fallback",
+        ),
+        pytest.param(
+            lambda c: ball_on_table(c, penetrance=1e-7, vel=(1.0, 0.0, 0.0)),
+            id="sliding_horizontal_velocity",
+        ),
+        pytest.param(
+            lambda c: ball_on_table(c, penetrance=1e-7, vel=(0.1, 1.0, 0.0)),
+            id="sliding_grazing_fallback",
+        ),
+        pytest.param(
+            lambda c: ball_on_table(
+                c, penetrance=1e-7, vel=(1.0, 0.0, 0.5), s=airborne
+            ),
+            id="airborne_bouncing_up",
+        ),
+    ],
+)
+def test_3d_ball_on_table_stays_on_table(
+    cushion: LinearCushionSegment,
+    ball_factory,
+) -> None:
+    """After make_kiss, an on-table ball (z=R) must not penetrate the table.
+
+    Covers both branches (velocity and fallback) and motion states (stationary,
+    sliding, airborne with upward vz from a table bounce).
+    """
+    R = BallParams.default().R
+    ball = ball_factory(cushion)
+
+    make_kiss_linear(ball, cushion)
+
+    assert ball.state.rvw[0, 2] >= R - 1e-12, (
+        f"Ball penetrated the table: z={ball.state.rvw[0, 2]}, R={R}"
+    )
+    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
+        R + MIN_DIST, abs=1e-12
+    )

--- a/tests/physics/resolve/ball_cushion/test_make_kiss.py
+++ b/tests/physics/resolve/ball_cushion/test_make_kiss.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from pooltool import ptmath
-from pooltool.constants import MIN_DIST, airborne, sliding, stationary
+from pooltool.constants import MIN_DIST, airborne, rolling, sliding, stationary
 from pooltool.objects import (
     Ball,
     BallParams,
@@ -214,3 +214,64 @@ def test_airborne_overlapping_ball_on_table_lands_on_table(
         f"Airborne ball not on table: z={ball.state.rvw[0, 2]}, R={R}"
     )
     assert dist_to_cushion_axis(ball, cushion) == pytest.approx(R + MIN_DIST, abs=1e-12)
+
+
+def test_airborne_stress(cushion: LinearCushionSegment) -> None:
+    """Random airborne configurations all satisfy dist == R + spacer after make_kiss.
+
+    Sweeps theta, penetrance, and 3D velocity. Covers both branches: the velocity
+    branch (most cases) and the fallback (grazing or velocity-parallel-to-axis).
+    """
+    R = BallParams.default().R
+    rng = np.random.default_rng(42)
+    N = 50
+
+    for _ in range(N):
+        theta_deg = float(rng.uniform(-85.0, 85.0))
+        penetrance = float(rng.uniform(-0.01, 0.005))
+        vel_dir = rng.standard_normal(3)
+        vel_dir /= np.linalg.norm(vel_dir)
+        speed = float(rng.uniform(0.1, 2.0))
+        vel = (
+            float(speed * vel_dir[0]),
+            float(speed * vel_dir[1]),
+            float(speed * vel_dir[2]),
+        )
+
+        ball = ball_at(cushion, theta_deg, penetrance, vel=vel, s=airborne)
+        make_kiss_linear(ball, cushion)
+
+        assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
+            R + MIN_DIST, abs=1e-12
+        ), (
+            f"airborne case failed: theta_deg={theta_deg}, penetrance={penetrance}, "
+            f"vel={vel}"
+        )
+
+
+def test_nonairborne_stress(cushion: LinearCushionSegment) -> None:
+    """Random sliding/rolling configurations all satisfy dist == R + spacer after make_kiss.
+
+    Sweeps penetrance, xy velocity, and motion state (sliding vs rolling).
+    """
+    R = BallParams.default().R
+    rng = np.random.default_rng(42)
+    states = (sliding, rolling)
+    N = 50
+
+    for _ in range(N):
+        penetrance = float(rng.uniform(-0.01, 0.005))
+        vel_xy = rng.standard_normal(2)
+        vel_xy /= np.linalg.norm(vel_xy)
+        speed = float(rng.uniform(0.1, 2.0))
+        vel = (float(speed * vel_xy[0]), float(speed * vel_xy[1]), 0.0)
+        state = states[int(rng.integers(0, 2))]
+
+        ball = ball_on_table(cushion, penetrance=penetrance, vel=vel, s=state)
+        make_kiss_linear(ball, cushion)
+
+        assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
+            R + MIN_DIST, abs=1e-12
+        ), (
+            f"non-airborne case failed: penetrance={penetrance}, vel={vel}, state={state}"
+        )

--- a/tests/physics/resolve/ball_cushion/test_make_kiss.py
+++ b/tests/physics/resolve/ball_cushion/test_make_kiss.py
@@ -6,28 +6,15 @@ from pooltool.constants import MIN_DIST, airborne, sliding, stationary
 from pooltool.objects import (
     Ball,
     BallParams,
-    CircularCushionSegment,
     LinearCushionSegment,
 )
 from pooltool.physics.resolve.ball_cushion import (
-    ball_ccushion_models,
     ball_lcushion_models,
 )
-from pooltool.physics.resolve.ball_cushion.core import FALLBACK_DISPLACEMENT_FACTOR
-from pooltool.physics.resolve.models import BallCCushionModel, BallLCushionModel
-
-GRAZING_THRESHOLD_INCIDENCE_DEG = float(
-    np.degrees(np.arccos(1.0 / FALLBACK_DISPLACEMENT_FACTOR))
-)
-"""Incidence angle (from cushion normal, degrees) above which make_kiss falls back.
-
-Derived from FALLBACK_DISPLACEMENT_FACTOR: the velocity-based displacement is
-``spacer / cos(incidence)``, so fallback triggers when
-``cos(incidence) < 1 / FALLBACK_DISPLACEMENT_FACTOR``.
-"""
+from pooltool.physics.resolve.models import BallLCushionModel
 
 
-def ball_at_3d_dist(
+def ball_at(
     cushion: LinearCushionSegment,
     theta_deg: float,
     penetrance: float = 0.0,
@@ -76,9 +63,9 @@ def ball_on_table(
     vel: tuple[float, float, float] = (0.0, 0.0, 0.0),
     s: int = sliding,
 ) -> Ball:
-    """Place a ball resting on the table (z = R) at a given 3D distance from the cushion axis.
+    """Place a ball resting on the table (z = R) at a given distance from the cushion axis.
 
-    Convenient specialization of :func:`ball_at_3d_dist` for the common scenario where
+    Convenient specialization of :func:`ball_at` for the common scenario where
     the cushion height exceeds R (so the on-table elevation angle is awkward to express
     in polar form).
 
@@ -107,36 +94,16 @@ def ball_on_table(
     return ball
 
 
-def xy_dist_to_cushion_axis(ball: Ball, cushion: LinearCushionSegment) -> float:
-    """XY-distance from ball center to the cushion axis (line through p1, p2)."""
-    pos = ball.state.rvw[0]
-    c = ptmath.point_on_line_closest_to_point(cushion.p1, cushion.p2, pos)
-    c[2] = pos[2]
-    return ptmath.norm3d(pos - c)
-
-
 def dist_to_cushion_axis(ball: Ball, cushion: LinearCushionSegment) -> float:
-    """3D-distance from ball center to the cushion axis (line through p1, p2)."""
+    """Distance from ball center to the cushion axis (line through p1, p2)."""
     pos = ball.state.rvw[0]
     c = ptmath.point_on_line_closest_to_point(cushion.p1, cushion.p2, pos)
-    return ptmath.norm3d(pos - c)
-
-
-def xy_dist_to_cushion_center(ball: Ball, cushion: CircularCushionSegment) -> float:
-    """XY-distance from ball center to the cushion center."""
-    pos = ball.state.rvw[0]
-    c = np.array([cushion.center[0], cushion.center[1], pos[2]])
     return ptmath.norm3d(pos - c)
 
 
 def make_kiss_linear(ball: Ball, cushion: LinearCushionSegment) -> None:
     """Run make_kiss (arbitrarily uses Mathavan model)"""
     ball_lcushion_models[BallLCushionModel.MATHAVAN_2010]().make_kiss(ball, cushion)
-
-
-def make_kiss_circular(ball: Ball, cushion: CircularCushionSegment) -> None:
-    """Run make_kiss (arbitrarily uses Mathavan model)"""
-    ball_ccushion_models[BallCCushionModel.MATHAVAN_2010]().make_kiss(ball, cushion)
 
 
 def assert_displaced_along_velocity(ball_before: Ball, ball: Ball) -> None:
@@ -150,30 +117,7 @@ def assert_displaced_along_velocity(ball_before: Ball, ball: Ball) -> None:
     )
 
 
-def assert_displaced_along_normal(
-    ball_before: Ball,
-    ball: Ball,
-    cushion: LinearCushionSegment | CircularCushionSegment,
-) -> None:
-    """Assert ball's displacement is along the cushion normal."""
-    displacement = ball.state.rvw[0] - ball_before.state.rvw[0]
-    normal = cushion.get_normal_xy(ball.state.rvw[0])
-    disp_norm = displacement / np.linalg.norm(displacement)
-    assert np.allclose(np.abs(np.dot(disp_norm, normal)), 1.0, atol=1e-10), (
-        f"Expected displacement along normal, "
-        f"got displacement={displacement}, normal={normal}"
-    )
-
-
-# -----------------------
-
-
-# -----------------------
-# 3D linear behavior: cushion is a 1D line at z = cushion_height. "Touch" means
-# the ball center is at 3D distance R from that line, not just R in xy.
-
-
-def test_3d_ball_on_table(cushion: LinearCushionSegment) -> None:
+def test_ball_on_table(cushion: LinearCushionSegment) -> None:
     """Ball resting on the table (z=R), slight overlap, horizontal velocity."""
     R = BallParams.default().R
     ball = ball_on_table(cushion, penetrance=1e-7, vel=(1.0, 0.0, 0.0))
@@ -181,39 +125,35 @@ def test_3d_ball_on_table(cushion: LinearCushionSegment) -> None:
 
     make_kiss_linear(ball, cushion)
 
-    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
-        R + MIN_DIST, abs=1e-12
-    )
+    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(R + MIN_DIST, abs=1e-12)
     assert_displaced_along_velocity(ball_before, ball)
 
 
-def test_3d_ball_above_cushion(cushion: LinearCushionSegment) -> None:
-    """Ball above cushion line, slight overlap, horizontal velocity."""
+def test_ball_above_cushion(cushion: LinearCushionSegment) -> None:
+    """Airborne ball above cushion line, slight overlap, horizontal velocity."""
     R = BallParams.default().R
-    ball = ball_at_3d_dist(cushion, theta_deg=15, penetrance=1e-7, vel=(1.0, 0.0, 0.0))
+    ball = ball_at(
+        cushion, theta_deg=15, penetrance=1e-7, vel=(1.0, 0.0, 0.0), s=airborne
+    )
     ball_before = ball.copy()
 
     make_kiss_linear(ball, cushion)
 
-    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
-        R + MIN_DIST, abs=1e-12
-    )
+    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(R + MIN_DIST, abs=1e-12)
     assert_displaced_along_velocity(ball_before, ball)
 
 
-def test_3d_ball_above_cushion_diagonal_velocity(cushion: LinearCushionSegment) -> None:
-    """Ball above cushion line with vz != 0; displacement still along 3D velocity."""
+def test_ball_above_cushion_diagonal_velocity(cushion: LinearCushionSegment) -> None:
+    """Airborne ball above cushion with vz != 0; displacement still along 3D velocity."""
     R = BallParams.default().R
     vel_unit = np.array([1.0, 0.0, -0.5]) / np.linalg.norm([1.0, 0.0, -0.5])
     vel = (float(vel_unit[0]), float(vel_unit[1]), float(vel_unit[2]))
-    ball = ball_at_3d_dist(cushion, theta_deg=15, penetrance=1e-7, vel=vel)
+    ball = ball_at(cushion, theta_deg=15, penetrance=1e-7, vel=vel, s=airborne)
     ball_before = ball.copy()
 
     make_kiss_linear(ball, cushion)
 
-    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
-        R + MIN_DIST, abs=1e-12
-    )
+    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(R + MIN_DIST, abs=1e-12)
     assert_displaced_along_velocity(ball_before, ball)
 
 
@@ -221,42 +161,56 @@ def test_3d_ball_above_cushion_diagonal_velocity(cushion: LinearCushionSegment) 
     "ball_factory",
     [
         pytest.param(
-            lambda c: ball_on_table(c, penetrance=1e-7, s=stationary),
-            id="stationary_fallback",
+            lambda c: ball_on_table(c, penetrance=-0.005, s=stationary),
+            id="stationary_fallback_lift",
         ),
         pytest.param(
             lambda c: ball_on_table(c, penetrance=1e-7, vel=(1.0, 0.0, 0.0)),
             id="sliding_horizontal_velocity",
         ),
         pytest.param(
-            lambda c: ball_on_table(c, penetrance=1e-7, vel=(0.1, 1.0, 0.0)),
-            id="sliding_grazing_fallback",
-        ),
-        pytest.param(
-            lambda c: ball_on_table(
-                c, penetrance=1e-7, vel=(1.0, 0.0, 0.5), s=airborne
-            ),
-            id="airborne_bouncing_up",
+            lambda c: ball_on_table(c, penetrance=-0.005, vel=(0.01, 1.0, 0.0)),
+            id="sliding_grazing_fallback_lift",
         ),
     ],
 )
-def test_3d_ball_on_table_stays_on_table(
+def test_nonairborne_ball_on_table_stays_on_table(
     cushion: LinearCushionSegment,
     ball_factory,
 ) -> None:
-    """After make_kiss, an on-table ball (z=R) must not penetrate the table.
+    """After make_kiss, a non-airborne ball must rest exactly on the table (z == R).
 
-    Covers both branches (velocity and fallback) and motion states (stationary,
-    sliding, airborne with upward vz from a table bounce).
+    Negative penetrance places the ball center beyond the touch radius, so the
+    fallback projects it toward the cushion line (which sits above the table).
+    The projected position lifts above R; the table constraint must rotate the
+    ball back down to z = R without changing its distance to the cushion line.
     """
     R = BallParams.default().R
     ball = ball_factory(cushion)
 
     make_kiss_linear(ball, cushion)
 
-    assert ball.state.rvw[0, 2] >= R - 1e-12, (
-        f"Ball penetrated the table: z={ball.state.rvw[0, 2]}, R={R}"
+    assert ball.state.rvw[0, 2] == pytest.approx(R, abs=1e-12), (
+        f"Non-airborne ball not on table: z={ball.state.rvw[0, 2]}, R={R}"
     )
-    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
-        R + MIN_DIST, abs=1e-12
+    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(R + MIN_DIST, abs=1e-12)
+
+
+def test_airborne_overlapping_ball_on_table_lands_on_table(
+    cushion: LinearCushionSegment,
+) -> None:
+    """Airborne overlapping ball at z=R with upward vz ends up exactly at z=R.
+
+    With positive penetrance, make_kiss moves backward along v (t < 0). vz > 0 means
+    the quadratic-solved z drops below R, so the ``airborne and z >= R`` short-circuit
+    in ``_constrain_to_table`` does not apply — the rotation pins z to R exactly.
+    """
+    R = BallParams.default().R
+    ball = ball_on_table(cushion, penetrance=1e-7, vel=(1.0, 0.0, 0.5), s=airborne)
+
+    make_kiss_linear(ball, cushion)
+
+    assert ball.state.rvw[0, 2] == pytest.approx(R, abs=1e-12), (
+        f"Airborne ball not on table: z={ball.state.rvw[0, 2]}, R={R}"
     )
+    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(R + MIN_DIST, abs=1e-12)

--- a/tests/physics/resolve/ball_cushion/test_make_kiss.py
+++ b/tests/physics/resolve/ball_cushion/test_make_kiss.py
@@ -14,6 +14,16 @@ from pooltool.physics.resolve.ball_cushion import (
 from pooltool.physics.resolve.models import BallLCushionModel
 
 
+def touch_radius(cushion: LinearCushionSegment) -> float:
+    """Distance from cushion axis to ball center at which the ball just touches the cushion surface."""
+    return BallParams.default().R + cushion.nose_radius
+
+
+def expected_post_kiss_dist(cushion: LinearCushionSegment) -> float:
+    """Distance from cushion axis to ball center expected after a successful make_kiss."""
+    return touch_radius(cushion) + MIN_DIST
+
+
 def ball_at(
     cushion: LinearCushionSegment,
     theta_deg: float,
@@ -34,15 +44,14 @@ def ball_at(
     Args:
         theta_deg: Elevation angle of the ball position from the cushion axis (degrees).
         penetrance: Effective dr inside the touch radius. ``penetrance = 0`` puts the
-            ball center at distance R from the cushion axis (just touching).
-            Positive values place the ball overlapping the cushion; negative values
-            place it separated.
+            ball center at distance ``R + nose_radius`` from the cushion axis
+            (just touching the cushion surface). Positive values place the ball
+            overlapping the cushion; negative values place it separated.
 
     Assumes the cushion is along the y-axis (as in the conftest fixture).
     """
-    R = BallParams.default().R
     h_cushion = cushion.p1[2]
-    r = R - penetrance
+    r = touch_radius(cushion) - penetrance
     theta_rad = np.radians(theta_deg)
     xb = -r * np.cos(theta_rad)
     zb = h_cushion + r * np.sin(theta_rad)
@@ -71,16 +80,16 @@ def ball_on_table(
 
     Args:
         penetrance: Effective dr inside the touch radius. ``penetrance = 0`` puts the
-            ball center at distance R from the cushion axis (just touching).
-            Positive values place the ball overlapping the cushion; negative values
-            place it separated.
+            ball center at distance ``R + nose_radius`` from the cushion axis
+            (just touching the cushion surface). Positive values place the ball
+            overlapping the cushion; negative values place it separated.
 
     The ball is placed on the -x side, at y = 0. Assumes the cushion is along the
     y-axis (as in the conftest fixture).
     """
     R = BallParams.default().R
     h_cushion = cushion.p1[2]
-    r = R - penetrance
+    r = touch_radius(cushion) - penetrance
     xy_dist = float(np.sqrt(r**2 - (R - h_cushion) ** 2))
 
     ball = Ball("cue")
@@ -119,19 +128,19 @@ def assert_displaced_along_velocity(ball_before: Ball, ball: Ball) -> None:
 
 def test_ball_on_table(cushion: LinearCushionSegment) -> None:
     """Ball resting on the table (z=R), slight overlap, horizontal velocity."""
-    R = BallParams.default().R
     ball = ball_on_table(cushion, penetrance=1e-7, vel=(1.0, 0.0, 0.0))
     ball_before = ball.copy()
 
     make_kiss_linear(ball, cushion)
 
-    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(R + MIN_DIST, abs=1e-12)
+    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
+        expected_post_kiss_dist(cushion), abs=1e-12
+    )
     assert_displaced_along_velocity(ball_before, ball)
 
 
 def test_ball_above_cushion(cushion: LinearCushionSegment) -> None:
     """Airborne ball above cushion line, slight overlap, horizontal velocity."""
-    R = BallParams.default().R
     ball = ball_at(
         cushion, theta_deg=15, penetrance=1e-7, vel=(1.0, 0.0, 0.0), s=airborne
     )
@@ -139,13 +148,14 @@ def test_ball_above_cushion(cushion: LinearCushionSegment) -> None:
 
     make_kiss_linear(ball, cushion)
 
-    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(R + MIN_DIST, abs=1e-12)
+    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
+        expected_post_kiss_dist(cushion), abs=1e-12
+    )
     assert_displaced_along_velocity(ball_before, ball)
 
 
 def test_ball_above_cushion_diagonal_velocity(cushion: LinearCushionSegment) -> None:
     """Airborne ball above cushion with vz != 0; displacement still along 3D velocity."""
-    R = BallParams.default().R
     vel_unit = np.array([1.0, 0.0, -0.5]) / np.linalg.norm([1.0, 0.0, -0.5])
     vel = (float(vel_unit[0]), float(vel_unit[1]), float(vel_unit[2]))
     ball = ball_at(cushion, theta_deg=15, penetrance=1e-7, vel=vel, s=airborne)
@@ -153,7 +163,9 @@ def test_ball_above_cushion_diagonal_velocity(cushion: LinearCushionSegment) -> 
 
     make_kiss_linear(ball, cushion)
 
-    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(R + MIN_DIST, abs=1e-12)
+    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
+        expected_post_kiss_dist(cushion), abs=1e-12
+    )
     assert_displaced_along_velocity(ball_before, ball)
 
 
@@ -193,7 +205,9 @@ def test_nonairborne_ball_on_table_stays_on_table(
     assert ball.state.rvw[0, 2] == pytest.approx(R, abs=1e-12), (
         f"Non-airborne ball not on table: z={ball.state.rvw[0, 2]}, R={R}"
     )
-    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(R + MIN_DIST, abs=1e-12)
+    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
+        expected_post_kiss_dist(cushion), abs=1e-12
+    )
 
 
 def test_airborne_overlapping_ball_on_table_lands_on_table(
@@ -213,16 +227,18 @@ def test_airborne_overlapping_ball_on_table_lands_on_table(
     assert ball.state.rvw[0, 2] == pytest.approx(R, abs=1e-12), (
         f"Airborne ball not on table: z={ball.state.rvw[0, 2]}, R={R}"
     )
-    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(R + MIN_DIST, abs=1e-12)
+    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
+        expected_post_kiss_dist(cushion), abs=1e-12
+    )
 
 
 def test_airborne_stress(cushion: LinearCushionSegment) -> None:
-    """Random airborne configurations all satisfy dist == R + spacer after make_kiss.
+    """Random airborne configurations all satisfy dist == R + nose_radius + spacer after make_kiss.
 
     Sweeps theta, penetrance, and 3D velocity. Covers both branches: the velocity
     branch (most cases) and the fallback (grazing or velocity-parallel-to-axis).
     """
-    R = BallParams.default().R
+    expected = expected_post_kiss_dist(cushion)
     rng = np.random.default_rng(42)
     N = 50
 
@@ -242,7 +258,7 @@ def test_airborne_stress(cushion: LinearCushionSegment) -> None:
         make_kiss_linear(ball, cushion)
 
         assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
-            R + MIN_DIST, abs=1e-12
+            expected, abs=1e-12
         ), (
             f"airborne case failed: theta_deg={theta_deg}, penetrance={penetrance}, "
             f"vel={vel}"
@@ -250,11 +266,11 @@ def test_airborne_stress(cushion: LinearCushionSegment) -> None:
 
 
 def test_nonairborne_stress(cushion: LinearCushionSegment) -> None:
-    """Random sliding/rolling configurations all satisfy dist == R + spacer after make_kiss.
+    """Random sliding/rolling configurations all satisfy dist == R + nose_radius + spacer after make_kiss.
 
     Sweeps penetrance, xy velocity, and motion state (sliding vs rolling).
     """
-    R = BallParams.default().R
+    expected = expected_post_kiss_dist(cushion)
     rng = np.random.default_rng(42)
     states = (sliding, rolling)
     N = 50
@@ -271,7 +287,7 @@ def test_nonairborne_stress(cushion: LinearCushionSegment) -> None:
         make_kiss_linear(ball, cushion)
 
         assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
-            R + MIN_DIST, abs=1e-12
+            expected, abs=1e-12
         ), (
             f"non-airborne case failed: penetrance={penetrance}, vel={vel}, state={state}"
         )

--- a/tests/physics/resolve/ball_cushion/test_make_kiss.py
+++ b/tests/physics/resolve/ball_cushion/test_make_kiss.py
@@ -232,6 +232,55 @@ def test_airborne_overlapping_ball_on_table_lands_on_table(
     )
 
 
+def test_velocity_parallel_to_cushion_axis_falls_back(
+    cushion: LinearCushionSegment,
+) -> None:
+    """A ball travelling exactly along the cushion axis still gets a valid position.
+
+    With the velocity purely along the axis there is no perpendicular component, so
+    the quadratic degenerates to ``0 = gamma`` and yields no real root. make_kiss must
+    fall back to perpendicular positioning rather than propagating the non-finite root
+    into the ball's position.
+    """
+    R = BallParams.default().R
+    ball = ball_on_table(cushion, penetrance=1e-7, vel=(0.0, 1.0, 0.0))
+
+    make_kiss_linear(ball, cushion)
+
+    assert np.all(np.isfinite(ball.state.rvw[0])), (
+        f"Non-finite position: {ball.state.rvw[0]}"
+    )
+    assert ball.state.rvw[0, 2] == pytest.approx(R, abs=1e-12)
+    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
+        expected_post_kiss_dist(cushion), abs=1e-12
+    )
+
+
+def test_ball_directly_above_cushion_axis(cushion: LinearCushionSegment) -> None:
+    """A ball on the vertical through the cushion axis is placed at the target distance.
+
+    Placed exactly on the vertical through the axis, the ball has no horizontal offset
+    and therefore no side of the cushion to be rotated back down onto.
+    ``_constrain_to_table`` must still produce a unit direction and preserve the arm
+    length, rather than collapsing the horizontal component and leaving the ball inside
+    the cushion. The position is built directly rather than via :func:`ball_at`, since
+    ``cos(radians(90))`` is not exactly zero and would leave a residual offset.
+    """
+    R = BallParams.default().R
+    ball = Ball("cue")
+    ball.state.rvw[0] = (0.0, 0.0, cushion.height + touch_radius(cushion) + 0.005)
+    ball.state.s = stationary
+
+    assert ball.state.rvw[0, 0] == 0.0
+
+    make_kiss_linear(ball, cushion)
+
+    assert ball.state.rvw[0, 2] == pytest.approx(R, abs=1e-12)
+    assert dist_to_cushion_axis(ball, cushion) == pytest.approx(
+        expected_post_kiss_dist(cushion), abs=1e-12
+    )
+
+
 def test_airborne_stress(cushion: LinearCushionSegment) -> None:
     """Random airborne configurations all satisfy dist == R + nose_radius + spacer after make_kiss.
 


### PR DESCRIPTION
# What the algorithm does

The job: the detector hands make_kiss a ball that's slightly wrong — overlapping the cushion by a hair, or
floating a hair away — because floating-point. Before the resolver computes the bounce, the ball needs to
be exactly barely-touching.

# The old 2D way

treat the cushion as a flat vertical wall, shove the ball perpendicular to it.

# The new 3D way

Five steps:

1. Model the cushion as a pipe. The nose is a cylinder of radius nose_radius running along the p1→p2 line.
The ball is just touching when its center sits at distance R + nose_radius from the pipe's centerline.
2. Slide the ball along its own velocity, not perpendicular. Ask: "at what time t — forward or backward —
along its straight-line path is the ball at exactly the right distance from the centerline?" That's a
quadratic in t. Take the root closest to zero (smallest correction) and move to r + t*v. This beats shoving
it sideways because you're following the path the ball actually took, which is more accurate and also reduces
likelihood of intersecting with an object as a result of the nudge.
3. Only the perpendicular plane matters. Strip out the components of position and velocity that point
along the cushion axis, since sliding along a pipe doesn't change your distance from it. That's what makes
it a clean quadratic instead of something ugly.
4. Then fix the height. Step 2 can leave the ball at a physically wrong height — sunk into the table, or
hovering above it. _constrain_to_table spins the ball around the pipe's axis, like a bead on a wire, until
the height is right: exactly z = R if it's on the table, at least z = R if airborne. Because it's a
rotation about the axis, the distance to the pipe never changes — the spacing from step 2 survives intact.
5. Fallback. If the ball isn't moving, or the correction would be absurd (grazing shot), skip the velocity
trick: push straight out perpendicular from the centerline, then apply the same height fix.

The clever part is step 4. Two constraints that would normally fight — distance-from-cushion and
height-above-table — and rotating about the cushion axis satisfies the second for free without disturbing
the first.

---

This doesn't handle circular cushion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ball-to-cushion contact resolution for more accurate positioning and motion.
  - Better handles angled, airborne, stationary, and edge-case collisions.
  - Preserves airborne behavior while ensuring balls resting on the table remain correctly constrained.
  - Improved fallback handling for challenging or invalid collision scenarios.
  - Enhanced consistency across linear cushions and circular pocket cushions.

- **Tests**
  - Added broad coverage for cushion contact behavior, including randomized and degenerate-motion cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->