### PR TITLE
Position-determined linear cushion normals

### DIFF
--- a/pooltool/objects/table/components.py
+++ b/pooltool/objects/table/components.py
@@ -143,19 +143,6 @@ class LinearCushionSegment:
         axis = self.p2 - self.p1
         return axis / ptmath.norm3d(axis)
 
-    @cached_property
-    def normal(self) -> NDArray[np.float64]:
-        """The line's normal vector, with the z-component zeroed prior to normalization.
-
-        Warning:
-            The returned normal vector is arbitrarily directed, meaning it may point
-            away from the table surface, rather than towards it. This nonideality is
-            properly handled in downstream simulation logic, however if you're using
-            this method for custom purposes, you may want to reverse the direction of
-            this vector by negating it.
-        """
-        return ptmath.unit_vector(np.array([self.lx, self.ly, 0]))
-
     def get_normal_xy(self, xyz: NDArray[np.float64]) -> NDArray[np.float64]:
         """Calculates the normal vector for a ball contacting the cushion.
 

--- a/pooltool/objects/table/components.py
+++ b/pooltool/objects/table/components.py
@@ -159,12 +159,10 @@ class LinearCushionSegment:
     def get_normal_xy(self, xyz: NDArray[np.float64]) -> NDArray[np.float64]:
         """Calculates the normal vector for a ball contacting the cushion.
 
-        Warning:
-            The returned normal vector is arbitrarily directed, meaning it may point
-            away from the table surface, rather than towards it. This nonideality is
-            properly handled in downstream simulation logic, however if you're using
-            this method for custom purposes, you may want to reverse the direction of
-            this vector by negating it.
+        The normal is directed from the cushion's line toward ``xyz``, so for a ball
+        on the playing surface it points away from the cushion and into the table.
+        Which side ``xyz`` lies on is determined by the sign of the general form line
+        equation (see :meth:`lx`) evaluated at ``xyz``.
 
         Args:
             xyz:
@@ -175,13 +173,10 @@ class LinearCushionSegment:
         Returns:
             NDArray[np.float64]:
                 The line's normal vector, with the z-component zeroed prior to normalization.
-
-        Note:
-            - This method only exists for call signature parity with
-              :meth:`pooltool.objects.CircularCushionSegment.get_normal_xy`. Consider using
-              :meth:`normal` instead.
         """
-        return self.normal
+        x, y, _ = xyz
+        normal = ptmath.unit_vector(np.array([self.lx, self.ly, 0]))
+        return normal if self.lx * x + self.ly * y + self.l0 >= 0 else -normal
 
     def get_normal_3d(self, xyz: NDArray[np.float64]) -> NDArray[np.float64]:
         """Calculates the 3D normal vector for a point contacting the cushion.

--- a/pooltool/objects/table/render.py
+++ b/pooltool/objects/table/render.py
@@ -53,18 +53,15 @@ class TableRender(Render):
         ):
             raise NotImplementedError()
 
-        # Make 4 planes
+        # Make 4 planes, each with its normal facing into the table
         # For diagram of cushion ids, see
         # https://ekiefl.github.io/2020/12/20/pooltool-alg/#ball-cushion-collision-times
+        table_center = np.array([*self._table.center, 0.0])
         for cushion_id in ["3", "9", "12", "18"]:
             cushion = self._table.cushion_segments.linear[cushion_id]
 
             x1, y1, z1 = cushion.p1
-
-            n1, n2, n3 = cushion.normal
-            if cushion_id in ["9", "12"]:
-                # These normals need to be flipped
-                n1, n2, n3 = -n1, -n2, -n3
+            n1, n2, n3 = cushion.get_normal_xy(table_center)
 
             collision_node = self.nodes["table"].attachNewNode(
                 CollisionNode(f"cushion_cplane_{cushion_id}")

--- a/pooltool/physics/resolve/ball_cushion/han_2005/model.py
+++ b/pooltool/physics/resolve/ball_cushion/han_2005/model.py
@@ -90,8 +90,7 @@ def han2005(rvw, xy_normal, R, m, h, e_c, f_c):
 
 
 def _solve(ball: Ball, cushion: Cushion) -> tuple[Ball, Cushion]:
-    xy_normal = cushion.get_normal_xy(ball.xyz)
-    xy_normal = xy_normal if np.dot(xy_normal, ball.vel) > 0 else -xy_normal
+    xy_normal = -cushion.get_normal_xy(ball.xyz)
     rvw = han2005(
         rvw=ball.state.rvw,
         xy_normal=xy_normal,

--- a/pooltool/physics/resolve/ball_cushion/mathavan_2010/model.py
+++ b/pooltool/physics/resolve/ball_cushion/mathavan_2010/model.py
@@ -633,10 +633,9 @@ def solve_mathavan(
 
     rvw = ball.state.rvw
 
-    # Ensure the normal is pointing in the same direction as the ball's velocity.
-    normal = cushion.get_normal_xy(ball.xyz)
-    if np.dot(normal, rvw[1]) <= 0:
-        normal = -normal
+    # get_normal_xy points from the cushion toward the ball. Here the normal must point
+    # from the ball into the cushion, hence the negation.
+    normal = -cushion.get_normal_xy(ball.xyz)
 
     # Rotate the ball's state into the cushion frame.
     psi = ptmath.angle(normal)

--- a/pooltool/physics/resolve/ball_cushion/unrealistic/__init__.py
+++ b/pooltool/physics/resolve/ball_cushion/unrealistic/__init__.py
@@ -1,7 +1,6 @@
 """An unrealistic ball-cushion model"""
 
 import attrs
-import numpy as np
 
 import pooltool.constants as const
 import pooltool.ptmath as ptmath
@@ -31,20 +30,9 @@ def _solve(
     """
     rvw = ball.state.rvw
 
-    # Two things about the normal:
-    #   1) Cushions have a get_normal_xy method that returns the normal. For linear
-    #      cushions this is determined solely by it's geometry. For circular
-    #      cushions, the normal is a function of the ball's position (specifically,
-    #      it is the line connecting the ball's and cushion's centers). To retain
-    #      symmetry between method calls, both linear and circular cushion segments
-    #      accept `xyz` as a parameter
-    #   2) The cushion normal is arbitrarily assigned to face either into the table
-    #      or away from the table. That's my bad--a mishap during development that
-    #      we're still living with the consequences of. The burden is that you must
-    #      assign a convention. Here I opt to orient the normal so it points away
-    #      from the playing surface.
-    normal = cushion.get_normal_xy(ball.xyz)
-    normal = normal if np.dot(normal, rvw[1]) > 0 else -normal
+    # get_normal_xy points from the cushion toward the ball. Here the convention is
+    # for the normal to point away from the playing surface, hence the negation.
+    normal = -cushion.get_normal_xy(ball.xyz)
 
     # Rotate frame of reference to the cushion frame. The cushion frame is defined
     # by the cushion's normal vector (convention: points away from table) being

--- a/tests/objects/table/test_components.py
+++ b/tests/objects/table/test_components.py
@@ -75,6 +75,36 @@ def test_linear_segment_copy(lin_seg):
     assert lin_seg is copy
 
 
+@pytest.mark.parametrize(
+    "p1, p2",
+    [
+        ([0, 0, 0], [0, 1, 0]),
+        ([0, 0, 0], [1, 0, 0]),
+        ([0, 0, 0], [1, 1, 0]),
+        ([1, 1, 0], [0, 0, 0]),
+        ([2, -1, 0], [-3, 4, 0]),
+    ],
+)
+@pytest.mark.parametrize("side", [+1, -1])
+def test_linear_segment_get_normal_xy_points_toward_xyz(p1, p2, side):
+    seg = LinearCushionSegment(
+        "lt",
+        p1=np.array(p1, dtype=np.float64),
+        p2=np.array(p2, dtype=np.float64),
+        nose_radius=0.005,
+    )
+    axis = seg.p2 - seg.p1
+    perpendicular = np.array([-axis[1], axis[0], 0.0])
+    xyz = (seg.p1 + seg.p2) / 2 + side * 0.3 * perpendicular + np.array([0, 0, 0.5])
+
+    normal = seg.get_normal_xy(xyz)
+
+    assert normal[2] == 0
+    assert np.linalg.norm(normal) == pytest.approx(1)
+    assert np.dot(normal, axis) == pytest.approx(0)
+    assert np.dot(normal, side * perpendicular) > 0
+
+
 def test_circular_segment_creation():
     # center array is length three
     with pytest.raises(AssertionError):


### PR DESCRIPTION
## Summary

`LinearCushionSegment.normal` was arbitrarily directed: it could point into or away from the table depending on the ordering of `p1` and `p2`. Every consumer had to compensate on its own. The 2D ball-cushion models re-oriented it against the ball's velocity, and the cue collision planes in the renderer hardcoded which cushion IDs needed flipping.

Meanwhile `get_normal_3d` (both segment types) and the circular segment's `get_normal_xy` were already well-determined by position, pointing from the cushion toward the queried point. This PR brings the linear `get_normal_xy` in line with that convention and removes the workarounds.

## Changes

- `LinearCushionSegment.get_normal_xy` now honors its `xyz` argument, choosing the sign from the general-form line equation evaluated at `xyz`. It points from the cushion toward the point, matching the circular segment and both `get_normal_3d` methods.
- The renderer derives cue collision plane normals by passing the table center to `get_normal_xy`, replacing the hardcoded flip of cushions 9 and 12. Verified numerically that the resulting normals are identical to the previous post-flip values on the default table.
- `LinearCushionSegment.normal` is removed. It had no remaining callers.
- The unrealistic, Han 2005, and Mathavan 2010 models drop their velocity-based orientation step and negate the position-based normal directly.
- A parametrized test covers `get_normal_xy` direction for vertical, horizontal, diagonal, and reversed-endpoint cushions from both sides.

## Test plan

- [x] Full suite passes (1391 tests)
- [x] Renderer plane normals on the default table match the previous post-flip values for cushions 3, 9, 12, and 18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YMGKSYZN4jLS5DGrbKFGV
